### PR TITLE
[designsystem] TopAppBar 컴포넌트 UI

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
@@ -1,0 +1,59 @@
+package com.droidknights.app2023.core.designsystem.component
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun KnightsTopAppBar(
+    @StringRes titleRes: Int,
+    navigationIcon: ImageVector,
+    navigationIconContentDescription: String?,
+    modifier: Modifier = Modifier,
+    colors: TopAppBarColors = TopAppBarDefaults.centerAlignedTopAppBarColors(),
+    onNavigationClick: () -> Unit = {},
+) {
+    CenterAlignedTopAppBar(
+        title = {
+            Text(
+                text = stringResource(id = titleRes),
+                style = MaterialTheme.typography.titleSmall,
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onNavigationClick) {
+                Icon(
+                    imageVector = navigationIcon,
+                    contentDescription = navigationIconContentDescription,
+                )
+            }
+        },
+        colors = colors,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun KnightsTopAppBarPreview() {
+    KnightsTopAppBar(
+        titleRes = android.R.string.untitled,
+        navigationIcon = Icons.Filled.ArrowBack,
+        navigationIconContentDescription = "Navigation icon"
+    )
+}


### PR DESCRIPTION
## Issue
- close #40

## Design
- 이슈 본문 참고

## Overview (Required)
- 공통으로 사용하기 위한 TopAppBar 컴포넌트 구현
- 피그마 기준으로 맞추는 대신 머티리얼 컴포넌트를 사용하도록 함
- 시안의 Close 아이콘이 우측에 정의되어 있는데 의도에 따라 다를 수 있지만 우선은 좌측 Navigation icon으로 통일


## Screenshot
![image](https://github.com/droidknights/DroidKnights2023_App/assets/28249981/29dd4fc3-33d6-4625-b33b-a8274d082b47)

