### PR TITLE
KnightsCard 클릭 로직 개선

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/Card.kt
@@ -11,14 +11,28 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun KnightsCard(
     modifier: Modifier = Modifier,
+    color: Color = Color(0xFFFFFFFF),
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = color,
+        shape = RoundedCornerShape(32.dp),
+        shadowElevation = 2.dp,
+        content = content,
+    )
+}
+
+@Composable
+fun KnightsCard(
+    modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
     color: Color = Color(0xFFFFFFFF),
     content: @Composable () -> Unit,
 ) {
     Surface(
         onClick = onClick,
-        modifier = modifier
-            .fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         color = color,
         shape = RoundedCornerShape(32.dp),
         shadowElevation = 2.dp,


### PR DESCRIPTION
## Issue
- close #75 

## Overview (Required)
- 클릭이 되지 않는 카드 상태를 분리하기 위해 별도의 컴포저블 추가
