### PR TITLE
TopAppBar를 UI 시안에 맞게 개선

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
@@ -1,59 +1,98 @@
 package com.droidknights.app2023.core.designsystem.component
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarColors
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KnightsTopAppBar(
     @StringRes titleRes: Int,
-    navigationIcon: ImageVector,
     navigationIconContentDescription: String?,
     modifier: Modifier = Modifier,
-    colors: TopAppBarColors = TopAppBarDefaults.centerAlignedTopAppBarColors(),
+    navigationType: TopAppBarNavigationType = TopAppBarNavigationType.Back,
+    contentColor: Color = Color(0xFF868686),
+    containerColor: Color = Color(0xFFFFFFFF),
     onNavigationClick: () -> Unit = {},
 ) {
-    CenterAlignedTopAppBar(
-        title = {
+    CompositionLocalProvider(LocalContentColor provides contentColor) {
+        val icon: @Composable (Modifier, imageVector: ImageVector) -> Unit =
+            { modifier, imageVector ->
+                IconButton(
+                    onClick = onNavigationClick,
+                    modifier = modifier.size(48.dp)
+                ) {
+                    Icon(
+                        imageVector = imageVector,
+                        contentDescription = navigationIconContentDescription,
+                    )
+                }
+            }
+
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(containerColor)
+                .then(modifier)
+        ) {
+            if (navigationType == TopAppBarNavigationType.Back) {
+                icon(
+                    Modifier.align(Alignment.CenterStart),
+                    Icons.Filled.ArrowBack
+                )
+            }
+            if (navigationType == TopAppBarNavigationType.Close) {
+                icon(
+                    Modifier.align(Alignment.CenterEnd),
+                    Icons.Filled.Close
+                )
+            }
             Text(
                 text = stringResource(id = titleRes),
                 style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.align(Alignment.Center)
             )
-        },
-        navigationIcon = {
-            IconButton(onClick = onNavigationClick) {
-                Icon(
-                    imageVector = navigationIcon,
-                    contentDescription = navigationIconContentDescription,
-                )
-            }
-        },
-        colors = colors,
-        modifier = modifier,
+        }
+    }
+}
+
+enum class TopAppBarNavigationType { Back, Close }
+
+@Preview
+@Composable
+private fun KnightsTopAppBarPreviewBack() {
+    KnightsTopAppBar(
+        titleRes = android.R.string.untitled,
+        navigationType = TopAppBarNavigationType.Back,
+        navigationIconContentDescription = "Navigation icon"
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
-private fun KnightsTopAppBarPreview() {
+private fun KnightsTopAppBarPreviewClose() {
     KnightsTopAppBar(
         titleRes = android.R.string.untitled,
-        navigationIcon = Icons.Filled.ArrowBack,
+        navigationType = TopAppBarNavigationType.Close,
         navigationIconContentDescription = "Navigation icon"
     )
 }


### PR DESCRIPTION
## Issue
- close #77 

## Overview (Required)
MaterialTopAppBar를 사용하지 않은 이유
1. 높이 변경에 제약이 있다
2. insets 여백을 스스로 계산해서 처리한다.
3. 아이콘 위치 변경에 제약이 있다.


## Screenshot

![image](https://github.com/droidknights/DroidKnights2023_App/assets/28249981/fcb81d1d-bda4-4c53-a39c-225823efb07e)

