### PR TITLE
[designsystem] TextChip 컴포저블

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/Chip.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/Chip.kt
@@ -1,0 +1,60 @@
+package com.droidknights.app2023.core.designsystem.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun TextChip(
+    text: String,
+    containerColor: Color,
+    labelColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(10.dp),
+        color = containerColor,
+    ) {
+        ProvideTextStyle(MaterialTheme.typography.labelMedium) {
+            Text(text = text, color = labelColor, modifier = Modifier.padding(TextChipPadding))
+        }
+    }
+}
+
+private val TextChipPadding = PaddingValues(12.dp, 2.dp, 12.dp, 2.dp)
+
+@Preview
+@Composable
+private fun TextChipPreview() {
+    MaterialTheme {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            TextChip(
+                "카테고리",
+                containerColor = Color(0xFF5D5D5D),
+                labelColor = Color(0xFFDCDCDC),
+            )
+            TextChip(
+                "Track 02",
+                containerColor = Color(0xFFA1ED00),
+                labelColor = Color(0xFF386524),
+            )
+            TextChip(
+                "16:45 발표",
+                containerColor = Color(0xFFD9F899),
+                labelColor = Color(0xFF386524),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- close #85 

## Link
- https://www.figma.com/file/FL7CdEyPjvhkJrtYEHAbXn/2023-Droid-Knights-App-_-KEB?type=design&node-id=120-628&mode=dev

## Overview (Required)
- 재사용 가능한 TextChip 컴포저블 추가

## Screenshot
![image](https://github.com/droidknights/DroidKnights2023_App/assets/28249981/b85f6f94-022d-4ff6-81f4-dbef143a90b1)
