### PR TITLE
[Contributor] 하단 Footer 추가

### DIFF
--- a/feature/contributor/src/main/java/com/droidknights/app2023/feature/contributor/ContributorScreen.kt
+++ b/feature/contributor/src/main/java/com/droidknights/app2023/feature/contributor/ContributorScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign.Companion.Center
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -107,6 +108,9 @@ private fun ContributorList(contributors: List<Contributor>) {
             val contributor = contributors[index]
             ContributorItem(contributor = contributor)
         }
+        item {
+            Footer()
+        }
     }
 }
 
@@ -149,6 +153,19 @@ private fun ContributorItem(contributor: Contributor) {
             )
         }
     }
+}
+
+@Composable
+private fun Footer() {
+    Text(
+        text = stringResource(id = R.string.contributor_footer),
+        style = MaterialTheme.typography.labelMedium,
+        color = Color(0xFFDCDCDC),
+        textAlign = Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 336.dp, bottom = 96.dp)
+    )
 }
 
 @Preview

--- a/feature/contributor/src/main/res/values/strings.xml
+++ b/feature/contributor/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="contributor_top_title">컨트리뷰터</string>
     <string name="contributor_chip">Contributor</string>
+    <string name="contributor_footer">Droid Knights 2023</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #98

## Overview (Required)
- 하단 스크롤 영역에 노출되는 Footer 뷰 추가
- LazyColumn Padding 영역 contentPadding으로 재설정

## Links
- https://www.figma.com/file/FL7CdEyPjvhkJrtYEHAbXn/2023-Droid-Knights-App-_-KEB?type=design&node-id=352%3A1786&mode=design&t=2rRf5qb39yyZB8Dk-1

## Screenshot
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/569a9996-b089-4a0c-a1a5-04a61258571a" width="300" />