### PR TITLE
[Setting] 상태바 만큼 여백을 주고 컨텐츠 그리기

### DIFF
--- a/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainScreen.kt
@@ -52,11 +52,13 @@ internal fun MainScreen(navigator: MainNavigator = rememberMainNavigator()) {
                     navController = navigator.navController,
                     startDestination = navigator.startDestination,
                 ) {
-                    settingNavGraph()
                     homeNavGraph(
                         padding = padding,
                         onSessionClick = { navigator.navigateSession() },
                         onContributorClick = { navigator.navigateContributor() },
+                    )
+                    settingNavGraph(
+                        padding = padding,
                     )
                     // TODO: 각 모듈로 이동
                     val content: @Composable (String) -> Unit = {

--- a/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/SettingScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -34,10 +35,11 @@ import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
 import com.droidknights.app2023.core.designsystem.theme.LocalDarkTheme
 
 @Composable
-internal fun SettingScreen() {
+internal fun SettingScreen(padding: PaddingValues) {
     Column(
         Modifier
             .background(color = Color(0xFFF9F9F9))
+            .padding(padding)
             .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -138,6 +140,6 @@ private fun ThemeCard(
 @Composable
 private fun SettingScreenPreview() {
     KnightsTheme {
-        SettingScreen()
+        SettingScreen(PaddingValues(0.dp))
     }
 }

--- a/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/navigation/SettingNavigation.kt
+++ b/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/navigation/SettingNavigation.kt
@@ -1,5 +1,6 @@
 package com.droidknights.app2023.feature.setting.navigation
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -10,9 +11,11 @@ fun NavController.navigateSetting(navOptions: NavOptions) {
     navigate(SettingRoute.route, navOptions)
 }
 
-fun NavGraphBuilder.settingNavGraph() {
+fun NavGraphBuilder.settingNavGraph(
+    padding: PaddingValues,
+) {
     composable(route = SettingRoute.route) {
-        SettingScreen()
+        SettingScreen(padding)
     }
 }
 


### PR DESCRIPTION
## Issue
- close #89 

## Overview (Required)
- 설정 화면의 컨텐츠 영역에 상태바 여백이 포함되도록 함(HomeScreen과 동일한 방법)

## Screenshot
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/9a51ce27-f517-44e8-ab71-6ffa56290daa" width="300" />
