### PR TITLE
#110 [designsystem] 테마에 맞는 이미지를 가져오기 위한 편의 함수 추가

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/res/Painter.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/res/Painter.kt
@@ -10,8 +10,4 @@ import com.droidknights.app2023.core.designsystem.theme.LocalDarkTheme
 fun rememberPainterResource(
     @DrawableRes lightId: Int,
     @DrawableRes darkId: Int = lightId,
-): Painter = if (LocalDarkTheme.current) {
-    painterResource(id = darkId)
-} else {
-    painterResource(id = lightId)
-}
+): Painter = painterResource(id = if (LocalDarkTheme.current) darkId else lightId)


### PR DESCRIPTION
## Issue
- close #110 

## Overview (Required)
- 라이트 모드/ 다크 모드에 맞는 이미지를 반환하도록 하는 컴포저블 함수

## Usage
```kotlin
val painter = rememberPainterResource(R.drawable.img_light, R.drawable.img_dark)
```
