### PR TITLE
[designsystem] 일부 폰트 스타일의 LineHeight과 LetterSpacing이 올바르지 않음

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/theme/Type.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/theme/Type.kt
@@ -114,12 +114,14 @@ internal val Typography = KnightsTypography(
     ),
     titleSmallM140 = SansSerifStyle.copy(
         fontSize = 14.sp,
-        lineHeight = 140.sp,
-        fontWeight = FontWeight.Medium
+        lineHeight = (19.6).sp,
+        fontWeight = FontWeight.Medium,
+        letterSpacing = (-2).sp
     ),
     titleSmallR140 = SansSerifStyle.copy(
         fontSize = 14.sp,
-        lineHeight = 140.sp,
+        lineHeight = (19.6).sp,
+        letterSpacing = (-2).sp
     ),
     titleSmallR = SansSerifStyle.copy(
         fontSize = 14.sp,


### PR DESCRIPTION
## Issue
- close #113

## Overview (Required)
- 다음 폰트 스타일의 LineHeight과 LetterSpacing 정의가 올바르지 않은 문제 수정
  - Title Small M14 140
  - Title Small R14 140
