### PR TITLE
[designsystem] NetworkImage Placeholder 크기가 전체 적용되지 않는 문제 해결

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ retrofitKotlinxSerializationJson = "1.0.0"
 kotlinxSerializationJson = "1.5.1"
 kotlinxDatetime = "0.2.1"
 
-landscapist = "2.2.1"
+landscapist = "2.2.5"
 
 junit4 = "4.13.2"
 junitVintageEngine = "5.10.0"


### PR DESCRIPTION
## Issue
- close #128

## Overview (Required)
- ~Placeholder가 모종의 이유로 부모의 Padding을 중복 적용하는 것으로 보여 Box로 감싼 후, padding을 주도록 변경~
  - ~Modifier로 padding을 주지 않으면 재현되지 않음을 확인~
- Landscapist 버전 업데이트로 해결

## Links
- 해당 이슈는 Landscapist 라이브러리 이슈로 리포트했습니다.
  - https://github.com/skydoves/landscapist/issues/317

## Screenshot
Before | After
:--: | :--:
<img width="300" alt="스크린샷 2023-07-31 오후 7 36 43" src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/7c071e31-af79-4c6a-815d-e1e9d1840f49"> | <img width="300" alt="스크린샷 2023-07-31 오후 10 46 58" src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/12af4d16-5a20-409d-b64b-1cb6c31272d1">

