### PR TITLE
[Home] 카드 UI 텍스트 컬러 테마 시스템 적용

### DIFF
--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/ContributorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/ContributorCard.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,13 +18,14 @@ import com.droidknights.app2023.core.designsystem.component.KnightsCard
 import com.droidknights.app2023.core.designsystem.theme.Black
 import com.droidknights.app2023.core.designsystem.theme.Green03
 import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
+import com.droidknights.app2023.core.designsystem.theme.Neon05
 
 @Composable
 internal fun ContributorCard(
     onClick: () -> Unit,
 ) {
     KnightsCard(
-        color = CardBackgroundColor,
+        color = Neon05,
         onClick = onClick,
         modifier = Modifier.height(164.dp),
     ) {
@@ -59,8 +59,6 @@ internal fun ContributorCard(
         }
     }
 }
-
-private val CardBackgroundColor = Color(0xFFEEFFE7)
 
 @Preview
 @Composable

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SessionCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SessionCard.kt
@@ -7,19 +7,19 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.droidknights.app2023.core.designsystem.component.KnightsCard
+import com.droidknights.app2023.core.designsystem.theme.Black
+import com.droidknights.app2023.core.designsystem.theme.Graphite
 import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
+import com.droidknights.app2023.core.designsystem.theme.White
 
 @Composable
 internal fun SessionCard(
@@ -43,7 +43,7 @@ internal fun SessionCard(
             Text(
                 text = stringResource(id = R.string.session_card_title),
                 style = KnightsTheme.typography.headlineSmallBL,
-                color = Color(0xFF000000),
+                color = Black,
                 modifier = Modifier.padding(top = 12.dp),
             )
         }
@@ -54,13 +54,13 @@ internal fun SessionCard(
 private fun SessionCardCaption() {
     Box(
         modifier = Modifier
-            .background(Color(0xFF292929), RoundedCornerShape(32.dp))
+            .background(Graphite, RoundedCornerShape(32.dp))
             .padding(horizontal = 12.dp, vertical = 2.dp)
     ) {
         Text(
             text = stringResource(id = R.string.session_card_caption),
             style = KnightsTheme.typography.labelSmallM,
-            color = Color(0xFFFFFFFF),
+            color = White,
         )
     }
 }

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -1,7 +1,6 @@
 package com.droidknights.app2023.feature.home
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,14 +11,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
@@ -30,7 +28,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.droidknights.app2023.core.designsystem.component.KnightsCard
 import com.droidknights.app2023.core.designsystem.component.NetworkImage
+import com.droidknights.app2023.core.designsystem.theme.DuskGray
 import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
+import com.droidknights.app2023.core.designsystem.theme.PaleGray
 import com.droidknights.app2023.core.model.Sponsor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -48,7 +48,7 @@ internal fun SponsorCard(uiState: SponsorsUiState) {
                 Text(
                     text = stringResource(id = R.string.sponsor_card_title),
                     style = KnightsTheme.typography.headlineSmallBL,
-                    color = Color(0xFF000000),
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier.padding(top = 24.dp),
                 )
                 Text(
@@ -58,7 +58,7 @@ internal fun SponsorCard(uiState: SponsorsUiState) {
                         uiState.goldCount
                     ),
                     style = KnightsTheme.typography.titleSmallR,
-                    color = Color(0xFF868686),
+                    color = DuskGray,
                     modifier = Modifier.padding(top = 8.dp),
                 )
             }
@@ -108,13 +108,10 @@ private fun SponsorLogo(
         Sponsor.Grade.GOLD -> R.drawable.ic_crown_gold
         Sponsor.Grade.PLATINUM -> R.drawable.ic_crown_platinum
     }
-    Box(
-        modifier = Modifier
-            .background(color = Color(0xFFF9F9F9), shape = RoundedCornerShape(42.dp))
-    ) {
+    Box {
         NetworkImage(
             imageUrl = sponsor.imageUrl,
-            placeholder = ColorPainter(Color(0xFFF9F9F9)),
+            placeholder = ColorPainter(PaleGray),
             modifier = Modifier
                 .size(84.dp)
                 .clip(CircleShape)


### PR DESCRIPTION
## Issue
- close #156

## Overview (Required)
- 홈 카드에서의 하드코딩된 컬러 사용처를 모두 컬러 테마 시스템으로 변경

## Screenshot
Light mode | Dark mode
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/a736a3c2-18e9-4f1f-bd14-26f1399e06ea" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/755904f6-f91e-4486-a3f7-9bfb99cafc84" width="300" />
