### PR TITLE
fix: flow 반환 타입 함수 suspend 키워드 제거

### DIFF
--- a/core/data/src/main/java/com/droidknights/app/core/data/repository/DefaultSessionRepository.kt
+++ b/core/data/src/main/java/com/droidknights/app/core/data/repository/DefaultSessionRepository.kt
@@ -33,7 +33,7 @@ internal class DefaultSessionRepository @Inject constructor(
             ?: error("Session not found with id: $sessionId")
     }
 
-    override suspend fun getBookmarkedSessionIds(): Flow<Set<String>> {
+    override fun getBookmarkedSessionIds(): Flow<Set<String>> {
         return bookmarkIds.filterNotNull()
     }
 

--- a/core/data/src/main/java/com/droidknights/app/core/data/repository/SessionRepository.kt
+++ b/core/data/src/main/java/com/droidknights/app/core/data/repository/SessionRepository.kt
@@ -9,7 +9,7 @@ interface SessionRepository {
 
     suspend fun getSession(sessionId: String): Session
 
-    suspend fun getBookmarkedSessionIds(): Flow<Set<String>>
+    fun getBookmarkedSessionIds(): Flow<Set<String>>
 
     suspend fun bookmarkSession(sessionId: String, bookmark: Boolean)
 }

--- a/core/domain/src/main/java/com/droidknights/app/core/domain/usecase/GetBookmarkedSessionIdsUseCase.kt
+++ b/core/domain/src/main/java/com/droidknights/app/core/domain/usecase/GetBookmarkedSessionIdsUseCase.kt
@@ -8,7 +8,7 @@ class GetBookmarkedSessionIdsUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
 ) {
 
-    suspend operator fun invoke(): Flow<Set<String>> {
+    operator fun invoke(): Flow<Set<String>> {
         return sessionRepository.getBookmarkedSessionIds()
     }
 }

--- a/core/domain/src/main/java/com/droidknights/app/core/domain/usecase/GetBookmarkedSessionsUseCase.kt
+++ b/core/domain/src/main/java/com/droidknights/app/core/domain/usecase/GetBookmarkedSessionsUseCase.kt
@@ -10,7 +10,7 @@ class GetBookmarkedSessionsUseCase @Inject constructor(
     private val getBookmarkedSessionIdsUseCase: GetBookmarkedSessionIdsUseCase,
 ) {
 
-    suspend operator fun invoke(): Flow<List<Session>> =
+    operator fun invoke(): Flow<List<Session>> =
         combine(
             getSessionsUseCase(),
             getBookmarkedSessionIdsUseCase()

--- a/core/domain/src/main/java/com/droidknights/app/core/domain/usecase/GetSessionsUseCase.kt
+++ b/core/domain/src/main/java/com/droidknights/app/core/domain/usecase/GetSessionsUseCase.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.flow
 class GetSessionsUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
 ) {
-    suspend operator fun invoke(): Flow<List<Session>> {
+    operator fun invoke(): Flow<List<Session>> {
         return flow {
             emit(sessionRepository.getSessions())
         }

--- a/core/domain/src/test/java/com/droidknights/app/core/domain/usecase/FakeSessionRepository.kt
+++ b/core/domain/src/test/java/com/droidknights/app/core/domain/usecase/FakeSessionRepository.kt
@@ -18,7 +18,7 @@ internal class FakeSessionRepository(
         return sessions.first { it.id == sessionId }
     }
 
-    override suspend fun getBookmarkedSessionIds(): Flow<Set<String>> {
+    override fun getBookmarkedSessionIds(): Flow<Set<String>> {
         return flow { emit(bookmarkedSessionIds) }
     }
 

--- a/feature/session/src/test/java/com/droidknights/app/feature/session/SessionViewModelTest.kt
+++ b/feature/session/src/test/java/com/droidknights/app/feature/session/SessionViewModelTest.kt
@@ -41,7 +41,7 @@ internal class SessionViewModelTest {
     @Test
     fun `세션 데이터를 확인할 수 있다`() = runTest {
         // given
-        coEvery { getSessionsUseCase() } returns listOf(fakeSession)
+        coEvery { getSessionsUseCase() } returns flowOf(listOf(fakeSession))
         coEvery { getBookmarkedSessionIdsUseCase() } returns flowOf(emptySet())
         viewModel = SessionViewModel(getSessionsUseCase, getBookmarkedSessionIdsUseCase)
 


### PR DESCRIPTION
## Overview (Required)
- SessionRepository 내에 getBookmarkedSessionIds() 함수는 반환 타입이 Flow<Set<String>> 입니다. 따라서 해당 함수는 suspend 키워드가 필요 없기에 제거하였습니다. 
- 해당 함수를 사용하는 파일(GetBookmarkedSessionIdsUseCase, DefaultSessionRepository, FakeSessionRepository, SessionViewModelTest)에도 변경을 반영하였습니다.

