### PR TITLE
[feature/register-kmp-plugin] Make Kotlin Multiplatform Android/iOS Plugin

### DIFF
--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinMultiplatform.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinMultiplatform.kt
@@ -1,0 +1,22 @@
+package com.droidknights.app
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+internal fun Project.configureKotlinMultiplatform() {
+    with(pluginManager) {
+        apply("org.jetbrains.kotlin.multiplatform")
+    }
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class) {
+        kotlinOptions.jvmTarget = "17"
+    }
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink>().configureEach {
+        notCompatibleWithConfigurationCache("Configuration chache not supported for a system property read at configuration time")
+    }
+}
+
+fun Project.kotlin(action: KotlinMultiplatformExtension.() -> Unit) {
+    extensions.configure(action)
+}

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinMultiplatformIos.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinMultiplatformIos.kt
@@ -1,0 +1,63 @@
+package com.droidknights.app
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import java.util.Properties
+
+internal enum class Arch(val arch: String?) {
+    ARM("arm64"),
+    X86("x86_64"),
+    ALL(null);
+
+    companion object {
+        fun of(arch: String?): Arch {
+            return values().firstOrNull { it.arch == arch } ?: ALL
+        }
+    }
+}
+
+internal val Project.activeArch
+    get() = Arch.of(
+        rootProject.layout.projectDirectory.file("local.properties").asFile.takeIf { it.exists() }
+            ?.let {
+                Properties().apply {
+                    load(it.reader(Charsets.UTF_8))
+                }.getProperty("arch")
+            } ?: System.getenv("arch")
+    )
+
+
+internal fun Project.configureKotlinMultiplatformIos() {
+    kotlin {
+        when (activeArch) {
+            Arch.ARM -> iosSimulatorArm64()
+            Arch.X86 -> iosX64()
+            Arch.ALL -> {
+                iosArm64()
+                iosX64()
+                iosSimulatorArm64()
+            }
+        }
+        with(sourceSets) {
+            create("iosMain") {
+                dependsOn(getByName("commonMain"))
+                maybeCreate("iosArm64Main").dependsOn(this)
+                maybeCreate("iosX64Main").dependsOn(this)
+                maybeCreate("iosSimulatorArm64Main").dependsOn(this)
+            }
+
+            create("iosTest") {
+                dependsOn(getByName("commonTest"))
+                maybeCreate("iosArm64Test").dependsOn(this)
+                maybeCreate("iosX64Test").dependsOn(this)
+                maybeCreate("iosSimulatorArm64Test").dependsOn(this)
+            }
+        }
+
+        targets.withType<KotlinNativeTarget> {
+            compilations["main"].kotlinOptions.freeCompilerArgs += "-Xexport-kdoc"
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinMutliplatformAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinMutliplatformAndroid.kt
@@ -1,0 +1,37 @@
+package com.droidknights.app
+
+import com.android.build.gradle.TestExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+internal fun Project.configureKotlinMultiplatformAndroid() {
+    with(pluginManager) {
+        apply("com.android.library")
+    }
+
+    kotlin {
+        androidTarget {
+            compilations.all {
+                kotlinOptions {
+                    jvmTarget = "17"
+                }
+            }
+        }
+    }
+
+    extensions.configure<TestExtension> {
+        configureKotlinAndroid()
+        sourceSets {
+            getByName("main") {
+                assets.srcDirs("src/androidMain/assets")
+                java.srcDirs("src/androidMain/kotlin", "src/commonMain/kotlin")
+                res.srcDirs("src/androidMain/res")
+            }
+            getByName("test") {
+                assets.srcDirs("src/androidUnitTest/assets")
+                java.srcDirs("src/androidUnitTest/kotlin", "src/commonTest/kotlin")
+                res.srcDirs("src/androidUnitTest/res")
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/droidknights.kmp.android.gradle.kts
+++ b/build-logic/src/main/kotlin/droidknights.kmp.android.gradle.kts
@@ -1,0 +1,5 @@
+import com.droidknights.app.configureKotlinMultiplatform
+import com.droidknights.app.configureKotlinMultiplatformAndroid
+
+configureKotlinMultiplatform()
+configureKotlinMultiplatformAndroid()

--- a/build-logic/src/main/kotlin/droidknights.kmp.ios.gradle.kts
+++ b/build-logic/src/main/kotlin/droidknights.kmp.ios.gradle.kts
@@ -1,0 +1,5 @@
+import com.droidknights.app.configureKotlinMultiplatform
+import com.droidknights.app.configureKotlinMultiplatformIos
+
+configureKotlinMultiplatform()
+configureKotlinMultiplatformIos()


### PR DESCRIPTION
## Issue
- #273 

## Overview (Required)
- Kotlin Multiplatform 전환 이전에 필요한 Kotlin Multiplatform Gradle Plugin을 미리 제작했습니다.
- Class 형식의 Plugin으로 제작은 많이 해봤는데 함수로 이렇게 제작하는 건 또 새로운 경험이네요.

