### PR TITLE
[세션] 복수의 발표자 대응

### DIFF
--- a/feature/session/src/main/java/com/droidknights/app/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app/feature/session/SessionDetailScreen.kt
@@ -160,7 +160,12 @@ private fun SessionDetailContent(session: Session) {
         HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outline)
         Spacer(modifier = Modifier.height(40.dp))
 
-        SessionDetailSpeaker(session.speakers.first())
+        session.speakers.forEach { speaker ->
+            SessionDetailSpeaker(speaker)
+            if (speaker != session.speakers.last()) {
+                Spacer(modifier = Modifier.height(40.dp))
+            }
+        }
     }
 }
 

--- a/widget/src/main/kotlin/com/droidknights/app/widget/DroidKnightsWidget.kt
+++ b/widget/src/main/kotlin/com/droidknights/app/widget/DroidKnightsWidget.kt
@@ -24,7 +24,6 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import com.droidknights.app.core.designsystem.theme.KnightsGlanceTheme
-import com.droidknights.app.core.model.Session
 import com.droidknights.app.widget.DroidKnightsWidgetReceiver.Companion.KEY_SESSION_IDS
 import com.droidknights.app.widget.di.WidgetModule
 import dagger.hilt.EntryPoints
@@ -44,14 +43,16 @@ class DroidKnightsWidget : GlanceAppWidget() {
         provideContent {
             KnightsGlanceTheme {
                 val state = currentState(stringSetPreferencesKey(KEY_SESSION_IDS))
-                var list: List<Session> by remember(state) { mutableStateOf(listOf()) }
+                var widgetSessionCards: List<WidgetSessionCardUiState> by remember(state) {
+                    mutableStateOf(listOf())
+                }
 
                 LaunchedEffect(state) {
-                    list = arrayListOf<Session>().apply {
-                        state?.forEach {
-                            this.add(widgetModule.getSessionUseCase().invoke(it))
-                        }
-                    }
+                    widgetSessionCards = state?.map {
+                        WidgetSessionCardUiState(
+                            session = widgetModule.getSessionUseCase().invoke(it),
+                        )
+                    } ?: emptyList()
                 }
 
                 Column(
@@ -64,7 +65,7 @@ class DroidKnightsWidget : GlanceAppWidget() {
                     WidgetTitle()
                     Spacer(modifier = GlanceModifier.height(16.dp))
                     LazyColumn {
-                        items(list) {
+                        items(widgetSessionCards) {
                             WidgetSessionCard(it)
                         }
                     }

--- a/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCard.kt
+++ b/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCard.kt
@@ -22,18 +22,18 @@ import com.droidknights.app.core.model.Session
 import kotlinx.datetime.toJavaLocalDateTime
 
 @Composable
-internal fun WidgetSessionCard(session: Session) {
+internal fun WidgetSessionCard(uiState: WidgetSessionCardUiState) {
     val context = LocalContext.current
 
     Box(modifier = GlanceModifier.padding(bottom = 16.dp, end = 16.dp)) {
         Column(
             modifier = GlanceModifier.padding(16.dp).fillMaxWidth()
                 .cornerRadius(12.dp).background(GlanceTheme.colors.tertiaryContainer).clickable(
-                    actionStartActivityWithSessionId(context, session.id)
+                    actionStartActivityWithSessionId(context, uiState.session.id)
                 )
         ) {
             Text(
-                session.title,
+                uiState.session.title,
                 style = TextDefaults.defaultTextStyle.copy(
                     fontSize = 16.sp,
                     color = GlanceTheme.colors.onTertiaryContainer
@@ -41,7 +41,7 @@ internal fun WidgetSessionCard(session: Session) {
             )
             Row {
                 Text(
-                    session.toTimeString(),
+                    uiState.session.toTimeString(),
                     style = TextDefaults.defaultTextStyle.copy(
                         fontSize = 14.sp,
                         color = GlanceTheme.colors.onTertiaryContainer
@@ -49,7 +49,7 @@ internal fun WidgetSessionCard(session: Session) {
                 )
                 Spacer(modifier = GlanceModifier.width(4.dp))
                 Text(
-                    session.speakers.joinToString { it.name },
+                    uiState.speakerLabel,
                     style = TextDefaults.defaultTextStyle.copy(
                         fontSize = 14.sp,
                         color = GlanceTheme.colors.onTertiaryContainer

--- a/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCard.kt
+++ b/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCard.kt
@@ -49,8 +49,7 @@ internal fun WidgetSessionCard(session: Session) {
                 )
                 Spacer(modifier = GlanceModifier.width(4.dp))
                 Text(
-                    // FIXME : 2명 이상 발표자 있는 case에 대해 정상 동작하도록 수정 필요
-                    session.speakers.first().name,
+                    session.speakers.joinToString { it.name },
                     style = TextDefaults.defaultTextStyle.copy(
                         fontSize = 14.sp,
                         color = GlanceTheme.colors.onTertiaryContainer

--- a/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCardUiState.kt
+++ b/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCardUiState.kt
@@ -7,6 +7,5 @@ import com.droidknights.app.core.model.Session
 data class WidgetSessionCardUiState(
     val session: Session,
 ) {
-    val speakerLabel: String
-        get() = session.speakers.joinToString { it.name }
+    val speakerLabel: String by lazy { session.speakers.joinToString { it.name } }
 }

--- a/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCardUiState.kt
+++ b/widget/src/main/kotlin/com/droidknights/app/widget/WidgetSessionCardUiState.kt
@@ -1,0 +1,12 @@
+package com.droidknights.app.widget
+
+import androidx.compose.runtime.Immutable
+import com.droidknights.app.core.model.Session
+
+@Immutable
+data class WidgetSessionCardUiState(
+    val session: Session,
+) {
+    val speakerLabel: String
+        get() = session.speakers.joinToString { it.name }
+}


### PR DESCRIPTION
## Issue
- #283 

## Overview (Required)
- 복수 발표자일 경우에 세션 상세 정보와, 위젯에 모든 분들이 표시되도록 했습니다.
  - 복수 발표자에 관한 디자인 가이드라인이 없었기 때문에 일단 임의로 다른 뷰들을 참고해 Spacer의 크기를 지정했습니다.
  - 위젯의 경우, LaunchedEffect 내에서 UiState를 가공하도록 했습니다.

## Links
- [세션 상세 정보](https://www.figma.com/design/FL7CdEyPjvhkJrtYEHAbXn/2023-Droid-Knights-App-_-KEB?node-id=869-4709&t=brW4ek7b5V4tqVIx-0)

## Screenshot
### Detail
Before | After
:--: | :--:
<video src="https://github.com/droidknights/DroidKnightsApp/assets/81838716/4fb3cb13-b8cb-4f69-9188-0c7e0b6ba8ce" /> | <video src="https://github.com/droidknights/DroidKnightsApp/assets/81838716/5f573065-aac9-42a4-8e24-9f16090ba1e0"/>
### Widget
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnightsApp/assets/81838716/74e8a7b1-8e1b-4501-bf52-0de77bd2a800" width="300" /> |<img src="https://github.com/droidknights/DroidKnightsApp/assets/81838716/e0576061-aa35-4bf8-b5cf-5461d431f570" width="300" />
