### PR TITLE
[feature/#306] Apply Kotlin 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 # Created by https://www.toptal.com/developers/gitignore/api/androidstudio,android
 # Edit at https://www.toptal.com/developers/gitignore?templates=androidstudio,android
 
+### Kotlin ###
+# generated .kotlin
+.kotlin/
+
 ### Android ###
 # Built application files
 *.apk

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.android.gradlePlugin)
     implementation(libs.kotlin.gradlePlugin)
     implementation(libs.verify.detektPlugin)
+    compileOnly(libs.compose.compiler.gradle.plugin)
 }
 
 gradlePlugin {

--- a/build-logic/src/main/kotlin/com/droidknights/app/ComposeAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/ComposeAndroid.kt
@@ -2,23 +2,25 @@ package com.droidknights.app
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 
 internal fun Project.configureComposeAndroid() {
+    with(plugins) {
+        apply("org.jetbrains.kotlin.plugin.compose")
+    }
+
     val libs = extensions.libs
     androidExtension.apply {
         buildFeatures {
             compose = true
         }
-        composeOptions {
-            kotlinCompilerExtensionVersion =
-                libs.findVersion("androidxComposeCompiler").get().toString()
-        }
-        
+
         dependencies {
             val bom = libs.findLibrary("androidx-compose-bom").get()
             add("implementation", platform(bom))
             add("androidTestImplementation", platform(bom))
-            
+
             add("implementation", libs.findLibrary("androidx.compose.material3").get())
             add("implementation", libs.findLibrary("androidx.compose.ui").get())
             add("implementation", libs.findLibrary("androidx.compose.ui.tooling.preview").get())
@@ -28,5 +30,10 @@ internal fun Project.configureComposeAndroid() {
             add("debugImplementation", libs.findLibrary("androidx.compose.ui.tooling").get())
             add("debugImplementation", libs.findLibrary("androidx.compose.ui.testManifest").get())
         }
+    }
+
+    extensions.getByType<ComposeCompilerGradlePluginExtension>().apply {
+        enableStrongSkippingMode.set(true)
+        includeSourceInformation.set(true)
     }
 }

--- a/build-logic/src/main/kotlin/com/droidknights/app/ComposeAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/ComposeAndroid.kt
@@ -12,10 +12,6 @@ internal fun Project.configureComposeAndroid() {
 
     val libs = extensions.libs
     androidExtension.apply {
-        buildFeatures {
-            compose = true
-        }
-
         dependencies {
             val bom = libs.findLibrary("androidx-compose-bom").get()
             add("implementation", platform(bom))

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -1,15 +1,11 @@
-@file:Suppress("UnstableApiUsage")
-
 package com.droidknights.app
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
@@ -66,11 +62,6 @@ internal fun Project.configureKotlin() {
                     "-opt-in=kotlin.RequiresOptIn",
                 )
             )
-        }
-    }
-    extensions.getByType<KotlinProjectExtension>().apply {
-        sourceSets.all {
-            languageSettings.enableLanguageFeature("ExplicitBackingFields")
         }
     }
 }

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -7,8 +7,10 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * https://github.com/android/nowinandroid/blob/main/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
@@ -52,7 +54,7 @@ internal fun Project.configureKotlinAndroid() {
 }
 
 internal fun Project.configureKotlin() {
-    extensions.getByType<KotlinAndroidProjectExtension>().apply {
+    tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
             // Treat all Kotlin warnings as errors (disabled by default)
@@ -65,6 +67,8 @@ internal fun Project.configureKotlin() {
                 )
             )
         }
+    }
+    extensions.getByType<KotlinProjectExtension>().apply {
         sourceSets.all {
             languageSettings.enableLanguageFeature("ExplicitBackingFields")
         }

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -7,10 +7,8 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * https://github.com/android/nowinandroid/blob/main/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -5,8 +5,11 @@ package com.droidknights.app
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
@@ -51,15 +54,17 @@ internal fun Project.configureKotlinAndroid() {
 }
 
 internal fun Project.configureKotlin() {
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_17.toString()
+    extensions.getByType<KotlinAndroidProjectExtension>().apply {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
             // Treat all Kotlin warnings as errors (disabled by default)
             // Override by setting warningsAsErrors=true in your ~/.gradle/gradle.properties
             val warningsAsErrors: String? by project
-            allWarningsAsErrors = warningsAsErrors.toBoolean()
-            freeCompilerArgs = freeCompilerArgs + listOf(
-                "-opt-in=kotlin.RequiresOptIn",
+            allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+            freeCompilerArgs.set(
+                freeCompilerArgs.get() + listOf(
+                    "-opt-in=kotlin.RequiresOptIn",
+                )
             )
         }
     }

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -67,5 +67,8 @@ internal fun Project.configureKotlin() {
                 )
             )
         }
+        sourceSets.all {
+            languageSettings.enableLanguageFeature("ExplicitBackingFields")
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.verify.detekt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }
 
 apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-testManifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxComposeNavigation" }
 androidx-compose-navigation-test = { group = "androidx.navigation", name = "navigation-testing", version.ref = "androidxComposeNavigation" }
+compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ composeShimmer = "1.3.0"
 
 ## Kotlin Symbol Processing
 # https://github.com/google/ksp/
-ksp = "1.9.24-1.0.20"
+ksp = "2.0.0-1.0.21"
 
 ## Hilt
 # https://github.com/google/dagger/releases
@@ -55,9 +55,9 @@ retrofit = "2.11.0"
 
 ## Kotlin
 # https://github.com/JetBrains/kotlin
-kotlin = "1.9.24"
+kotlin = "2.0.0"
 # https://github.com/Kotlin/kotlinx.serialization
-kotlinxSerializationJson = "1.6.3"
+kotlinxSerializationJson = "1.7.0-RC"
 # https://github.com/Kotlin/kotlinx-datetime/releases
 kotlinxDatetime = "0.6.0"
 # https://github.com/Kotlin/kotlinx.collections.immutable
@@ -174,3 +174,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 verify-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
## Issue
- close #306 

## Overview (Required)
- Kotlin 2.0.0 버전을 적용합니다.
- 적용 중 이슈(trivial)
  - Explicit backing field를 적용하기 위해 compiler argument와 language setting을 적용하였는데 IDE 차원에서 아직 Backing field를 지원하지 않는다는것을 발견하였습니다. 그래서 해당 부분은 구현사항에서 제외하겠습니다.

<img width="451" alt="스크린샷 2024-05-30 오후 1 00 05" src="https://github.com/droidknights/DroidKnightsApp/assets/54518925/eefc0ed8-4c7f-4344-8adf-b21db3175c7a">

## Links
- [Kotlin 2.0으로 마이그레이션하기](https://medium.com/@l2hyunwoo/kotlin-2-0%EC%9C%BC%EB%A1%9C-%EB%A7%88%EC%9D%B4%EA%B7%B8%EB%A0%88%EC%9D%B4%EC%85%98%ED%95%98%EA%B8%B0-1742f294df51)

## 시연영상

https://github.com/droidknights/DroidKnightsApp/assets/54518925/2d5d0aac-d28e-420e-a2b8-af7e03b761e3


