### PR TITLE
fix: 탭 전환 시 화면 오버래핑 되는 현상 수정

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ baselineprofile = "1.2.4"
 # https://developer.android.com/develop/ui/compose/bom/bom-mapping
 androidxComposeBom = "2024.05.00"
 # https://developer.android.com/jetpack/androidx/releases/navigation
-androidxComposeNavigation = "2.8.0-beta02"
+androidxComposeNavigation = "2.8.0-beta06"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
 androidxComposeMaterial3 = "1.2.1"
 


### PR DESCRIPTION
## Overview (Required)
jetpack compose navigation에 대한 버전업을 했습니다. `beta02-> beta06`

탭 간 이동 시 화면이 overlap 되는 현상이 있습니다.
이 이슈는 `jetpack compose navigation 2.8.0-beta03`까지 나오는 버그이고,
현재 드로이드 나이츠 앱에서는 `beta02` 버전을 사용하고 있어서 생기는 문제입니다.
[동일한 버그에 대한 제기된 이슈 내용도 있습니다.](https://issuetracker.google.com/issues/338975163#comment7)

[navigation release note](https://developer.android.com/jetpack/androidx/releases/navigation?hl=ko#2.8.0-beta04)를 보시면 `beta04` 버전에 `predictive back gesture cancellation`(예측 백 제스처 취소)로 인한 애니메이션에 발생한 문제를 해결한 내용이 있는데요.
<img width="1454" alt="스크린샷 2024-08-16 오후 1 06 40" src="https://github.com/user-attachments/assets/c1d5d988-43f4-45f6-8283-617431f3082c">

릴리즈 노트 상으로는 제기한 버그와 다른 수정사항이지만, 직접 확인 결과 화면이 overlap 되는 현상이 해결되어 문의를 남겼고 `predictive back gesture cancellation`(예측 백 제스처 취소)로 인한 애니메이션에 발생한 문제와 동일한 문제로 판단되어 함께 수정되었다는 [답변](https://issuetracker.google.com/issues/338975163#comment12)을 받았습니다.
![스크린샷 2024-08-16 오후 12 12 17](https://github.com/user-attachments/assets/1e188061-6356-44f1-84fd-fb772f6693ac)

`compose navigation`의 현재 최신 버전은 `beta07`이지만, 해당 버전은 [compile sdk 버전이 35이상일 경우에 사용가능하기에](https://issuetracker.google.com/issues/358798728) `beta06`으로 버전업하였습니다.

## Links
- [동일한 버그에 대한 제기된 이슈 내용](https://issuetracker.google.com/issues/338975163#comment7)
- [compose navigation release note beta04](https://developer.android.com/jetpack/androidx/releases/navigation?hl=ko#2.8.0-beta04)
- [예측 백 제스처 취소 이슈에 대한 해결 내용](https://issuetracker.google.com/issues/346608857#comment5)
- [문의에 대한 답변](https://issuetracker.google.com/issues/338975163#comment12)
- [beta07이 compileSdk 35 이상일 경우에 사용 가능하다는 내용](https://issuetracker.google.com/issues/358798728)

## Screenshot
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/084ca3dc-5592-4226-b8fe-8cad1e564186" width="300" /> | <video src="https://github.com/user-attachments/assets/d945a427-8700-4ecf-9fb1-70f1e784f386" width="300" />
