### PR TITLE
[라이브러리] 디펜던시 최신화 for 2025 Droid Knights

### DIFF
--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew detekt
 
       - name: Upload Event File
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: "**/test-results/**/*.xml"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew :app:assembleRelease
 
       - name: Upload Release Build to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: app/build/outputs/apk/release/

--- a/baselineProfile/build.gradle.kts
+++ b/baselineProfile/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.droidknights.baselineprofile"
-    compileSdk = 34
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -17,7 +17,7 @@ internal fun Project.configureKotlinAndroid() {
 
     // Android settings
     androidExtension.apply {
-        compileSdk = 34
+        compileSdk = 35
 
         defaultConfig {
             minSdk = 28

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,49 +1,49 @@
 [versions]
 ## Android gradle plugin
-androidGradlePlugin = "8.3.2"
+androidGradlePlugin = "8.8.0"
 
 # https://github.com/google/desugar_jdk_libs/blob/master/CHANGELOG.md
-androidDesugarJdkLibs = "2.0.4"
+androidDesugarJdkLibs = "2.1.4"
 
 ## AndroidX
 # https://developer.android.com/jetpack/androidx/releases/core
-androidxCore = "1.13.1"
+androidxCore = "1.15.0"
 # https://developer.android.com/jetpack/androidx/releases/appcompat
 androidxAppCompat = "1.7.0"
 # https://developer.android.com/jetpack/androidx/releases/lifecycle
-androidxLifecycle = "2.8.1"
+androidxLifecycle = "2.8.7"
 # https://developer.android.com/jetpack/androidx/releases/activity
-androidxActivity = "1.9.0"
+androidxActivity = "1.10.0"
 # https://developer.android.com/jetpack/androidx/releases/datastore
-androidxDatastore = "1.1.1"
+androidxDatastore = "1.1.2"
 # https://developer.android.com/jetpack/androidx/releases/glance
-androidxGlance = "1.0.0"
+androidxGlance = "1.1.1"
 glanceExperimentalTools = "0.2.2"
 # https://developer.android.com/jetpack/androidx/releases/profileinstaller
-profileinstaller = "1.3.1"
+profileinstaller = "1.4.1"
 # https://androidx.tech/artifacts/benchmark/benchmark-baseline-profile-gradle-plugin/index.html
-baselineprofile = "1.2.4"
+baselineprofile = "1.3.3"
 
 ## Compose
 # https://developer.android.com/develop/ui/compose/bom/bom-mapping
-androidxComposeBom = "2024.05.00"
+androidxComposeBom = "2025.01.01"
 # https://developer.android.com/jetpack/androidx/releases/navigation
-androidxComposeNavigation = "2.8.0-beta02"
+androidxComposeNavigation = "2.8.6"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
-androidxComposeMaterial3 = "1.2.1"
+androidxComposeMaterial3 = "1.3.1"
 
 # https://github.com/skydoves/landscapist
-landscapist = "2.3.4"
+landscapist = "2.4.6"
 # https://github.com/valentinilk/compose-shimmer
-composeShimmer = "1.3.0"
+composeShimmer = "1.3.2"
 
 ## Kotlin Symbol Processing
 # https://github.com/google/ksp/
-ksp = "2.0.0-1.0.22"
+ksp = "2.1.0-1.0.29"
 
 ## Hilt
 # https://github.com/google/dagger/releases
-hilt = "2.51.1"
+hilt = "2.55"
 # https://developer.android.com/jetpack/androidx/releases/hilt
 hiltNavigationCompose = "1.2.0"
 
@@ -57,19 +57,19 @@ retrofit = "2.11.0"
 
 ## Kotlin
 # https://github.com/JetBrains/kotlin
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 # https://github.com/Kotlin/kotlinx.serialization
-kotlinxSerializationJson = "1.7.0"
+kotlinxSerializationJson = "1.8.0"
 # https://github.com/Kotlin/kotlinx-datetime/releases
-kotlinxDatetime = "0.6.0"
+kotlinxDatetime = "0.6.1"
 # https://github.com/Kotlin/kotlinx.collections.immutable
-kotlinxImmutable = "0.3.7"
+kotlinxImmutable = "0.3.8"
 
 ## Coroutine
 # https://github.com/cashapp/turbine
-turbine = "1.1.0"
+turbine = "1.2.0"
 # https://github.com/Kotlin/kotlinx.coroutines
-coroutine = "1.9.0-RC"
+coroutine = "1.10.1"
 
 ## license
 # https://developers.google.com/android/guides/opensource
@@ -81,26 +81,26 @@ ossLicensesPlugin = "0.10.6"
 junit4 = "4.13.2"
 # https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine
 junitVintageEngine = "5.10.2"
-ui-test-junit4 = "1.6.7"
+ui-test-junit4 = "1.7.7"
 # https://developer.android.com/jetpack/androidx/releases/test-uiautomator
 uiAutomator = "2.3.0"
-androidxTestRunner = "1.5.2"
+androidxTestRunner = "1.6.2"
 # https://developer.android.com/jetpack/androidx/releases/benchmark
-benchmarkMacroJunit4 = "1.2.4"
+benchmarkMacroJunit4 = "1.3.3"
 
 # # https://developer.android.com/jetpack/androidx/releases/test
-androidxTestExt = "1.1.5"
-androidxEspresso = "3.5.1"
+androidxTestExt = "1.2.1"
+androidxEspresso = "3.6.1"
 # # https://github.com/takahirom/roborazzi
-roborazzi = "1.20.0"
+roborazzi = "1.40.1"
 # https://github.com/robolectric/robolectric/releases
-robolectric = "4.12.2"
+robolectric = "4.14.1"
 # https://kotest.io/
 kotest = "5.9.0"
 # https://github.com/detekt/detekt
-detekt = "1.23.6"
+detekt = "1.23.7"
 # https://mockk.io/
-mockk = "1.13.11"
+mockk = "1.13.16"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@
 # https://gradle.org/releases/
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
(간단히 모든 의존성 버전을 올리고 앱 빌드 + 테스트를 돌려봤는데 잘 돌아가네요. 각 라이브러리들 업데이트 사항은 아직 확인하지 않았습니다.)
---

## Issue
- close #337 

## 작업사항
- compileSdk 34 -> 35
- gradle 8.8 -> 8.10.2
- 그 외 모든 라이브러리의 최신 버전 적용
- Github uploadActifacts action v3 -> v4 
  - 2025-01-31부터 업데이트 강제
  - ref. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
