### PR TITLE
[web-deployment] wasm build 결과물을 github pages에 배포한다

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -31,4 +31,4 @@ jobs:
       - name: kotlinUpgradeYarnLock
         run: ./gradlew kotlinUpgradeYarnLock
 
-      - run: ./gradlew :composeApp:wasmJsBrowserDistribution --stacktrace
+      - run: ./gradlew :composeApp:buildWebApp --stacktrace

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - develop-2025
   workflow_dispatch:
-  pull_request:
-    branches:
-      - develop-2025
 
 jobs:
   # Build job

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,61 @@
+# From KotlinConf App
+# https://github.com/JetBrains/kotlinconf-app/blob/main/.github/workflows/web-deploy.yml
+name: Publish Wasm App on GitHub Pages
+on:
+  push:
+    branches:
+      - develop-2025
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - develop-2025
+
+jobs:
+  # Build job
+  build:
+    name: Build Kotlin/Wasm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-java
+
+      - name: Run Gradle Tasks
+        run: ./gradlew :composeApp:buildWebApp
+
+      - name: Fix permissions
+        run: |
+          chmod -v -R +rX "composeApp/build/webApp/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: composeApp/build/webApp/
+
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Permissions
+        run: env | grep ACTIONS_ID_TOKEN_REQUEST_URL || echo "ACTIONS_ID_TOKEN_REQUEST_URL not set"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.kotlin.dsl.registering
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -104,4 +105,16 @@ compose.desktop {
             packageVersion = "1.0.0"
         }
     }
+}
+
+// From KotlinConf App
+// https://github.com/JetBrains/kotlinconf-app/blob/c81492ee57a8da67390d84ad29f41b08128fe0e1/shared/build.gradle.kts#L193
+val buildWebApp by tasks.registering(Copy::class) {
+    val wasmDist = "wasmJsBrowserDistribution"
+
+    from(tasks.named(wasmDist).get().outputs.files)
+
+    into(layout.buildDirectory.dir("webApp"))
+
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- wasm 타겟으로 빌드한 결과물을 Github Pages를 통해 배포한다.

## Links
- 참고링크: https://github.com/JetBrains/kotlinconf-app/blob/main/.github/workflows/web-deploy.yml

