### PR TITLE
[jvm-cd] 데스크탑 앱 PR/디벨롭 머지시에 빌드 결과 저장/PR 댓글 다는 기능 추가

### DIFF
--- a/.github/workflows/jvm-desktop-build.yml
+++ b/.github/workflows/jvm-desktop-build.yml
@@ -1,12 +1,25 @@
 name: Compose Desktop(JVM) CI
 
 on:
+  # 1) 포크 PR → 자동 빌드만
   pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - develop-2025
     paths-ignore:
       - 'iosApp/**'
       - 'kotlin-js-store/**'
+
+  # 2) PR 승인 후(관리자 수동 승인) → 코멘트 작성
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - develop-2025
+    paths-ignore:
+      - 'iosApp/**'
+      - 'kotlin-js-store/**'
+
+  # 3) develop-2025 브랜치에 푸시(머지 포함) → 빌드 + 3일짜리 아티팩트
   push:
     branches:
       - develop-2025
@@ -20,16 +33,24 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write    # PR 댓글을 달기 위해 필요
+  issues:   write       # PR 코멘트 작성 권한
+  pull-requests: write  # PR 코멘트 작성 권한
 
 jobs:
-  build-desktop:
+  build:
+    # pull_request 이벤트와 push 이벤트에서만 실행
+    if: >
+      github.event_name == 'pull_request' ||
+      github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
-      - name: Checkout repository
+      - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Java
         uses: ./.github/actions/setup-java
@@ -37,7 +58,6 @@ jobs:
       - name: Build Desktop Jar
         run: ./gradlew :composeApp:desktopJar --stacktrace
 
-      # PR 빌드 아티팩트 업로드 (1일 보관)
       - name: Upload artifact (PR)
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
@@ -46,20 +66,6 @@ jobs:
           path: composeApp/build/libs/*.jar
           retention-days: 1
 
-      # PR에 댓글로 아티팩트 링크 남기기
-      - name: Comment on PR with artifact link
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ✅ DroidKnights 데스크탑 앱의 빌드가 완료되었습니다!  
-            아래 링크를 통해 아티팩트를: 다운로드할 수 있습니다:
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      # develop-2025 머지(또는 직접 푸시) 시 아티팩트 업로드 (3일 보관)
       - name: Upload artifact (develop-2025)
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
@@ -67,3 +73,24 @@ jobs:
           name: desktop-jar
           path: composeApp/build/libs/*.jar
           retention-days: 3
+
+  comment:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Comment on PR with artifact link
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ✅ Compose Desktop(JVM) 빌드가 완료되었습니다!
+            아티팩트 다운로드 (1일 보관):  
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/jvm-desktop-build.yml
+++ b/.github/workflows/jvm-desktop-build.yml
@@ -1,28 +1,14 @@
 name: Compose Desktop(JVM) CI
 
 on:
-  # 1) 포크 PR → 자동 빌드만
   pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - develop-2025
+    types: [ opened, synchronize, reopened ]
+    branches: [ develop-2025 ]
     paths-ignore:
       - 'iosApp/**'
       - 'kotlin-js-store/**'
-
-  # 2) PR 승인 후(관리자 수동 승인) → 코멘트 작성
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches:
-      - develop-2025
-    paths-ignore:
-      - 'iosApp/**'
-      - 'kotlin-js-store/**'
-
-  # 3) develop-2025 브랜치에 푸시(머지 포함) → 빌드 + 3일짜리 아티팩트
   push:
-    branches:
-      - develop-2025
+    branches: [ develop-2025 ]
     paths-ignore:
       - 'iosApp/**'
       - 'kotlin-js-store/**'
@@ -33,20 +19,14 @@ concurrency:
 
 permissions:
   contents: read
-  issues:   write       # PR 코멘트 작성 권한
-  pull-requests: write  # PR 코멘트 작성 권한
 
 jobs:
   build:
-    # pull_request 이벤트와 push 이벤트에서만 실행
-    if: >
-      github.event_name == 'pull_request' ||
-      github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -58,7 +38,7 @@ jobs:
       - name: Build Desktop Jar
         run: ./gradlew :composeApp:desktopJar --stacktrace
 
-      - name: Upload artifact (PR)
+      - name: Upload artifact for PR
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
@@ -66,31 +46,10 @@ jobs:
           path: composeApp/build/libs/*.jar
           retention-days: 1
 
-      - name: Upload artifact (develop-2025)
+      - name: Upload artifact for develop-2025
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: desktop-jar
           path: composeApp/build/libs/*.jar
           retention-days: 3
-
-  comment:
-    if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Comment on PR with artifact link
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ✅ Compose Desktop(JVM) 빌드가 완료되었습니다!
-            아티팩트 다운로드 (1일 보관):  
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/jvm-desktop-build.yml
+++ b/.github/workflows/jvm-desktop-build.yml
@@ -1,32 +1,69 @@
-name: Compose Desktop(JVM) Build
+name: Compose Desktop(JVM) CI
 
 on:
+  pull_request:
+    branches:
+      - develop-2025
+    paths-ignore:
+      - 'iosApp/**'
+      - 'kotlin-js-store/**'
   push:
     branches:
       - develop-2025
-  pull_request:
     paths-ignore:
       - 'iosApp/**'
-      - 'kotlin-js-store'
+      - 'kotlin-js-store/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions: { }
+permissions:
+  contents: read
+  issues: write    # PR 댓글을 달기 위해 필요
 
 jobs:
-  build:
-    permissions:
-      contents: read
-
+  build-desktop:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup-java
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
 
-      - run: ./gradlew :composeApp:desktopJar --stacktrace
+      - name: Build Desktop Jar
+        run: ./gradlew :composeApp:desktopJar --stacktrace
+
+      # PR 빌드 아티팩트 업로드 (1일 보관)
+      - name: Upload artifact (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-jar
+          path: composeApp/build/libs/*.jar
+          retention-days: 1
+
+      # PR에 댓글로 아티팩트 링크 남기기
+      - name: Comment on PR with artifact link
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ✅ DroidKnights 데스크탑 앱의 빌드가 완료되었습니다!  
+            아래 링크를 통해 아티팩트를: 다운로드할 수 있습니다:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      # develop-2025 머지(또는 직접 푸시) 시 아티팩트 업로드 (3일 보관)
+      - name: Upload artifact (develop-2025)
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-jar
+          path: composeApp/build/libs/*.jar
+          retention-days: 3

--- a/.github/workflows/jvm-desktop-comment.yml
+++ b/.github/workflows/jvm-desktop-comment.yml
@@ -1,0 +1,35 @@
+name: Comment Desktop CI Artifacts
+
+on:
+  workflow_run:
+    workflows: [ "Compose Desktop(JVM) CI" ]
+    types: [ completed ]
+
+concurrency:
+  group: comment-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    # 이전 빌드가 성공했고, 그 빌드가 pull_request 이벤트로 실행된 경우에만 동작
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post artifact link to PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.workflow_run.repository.full_name }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          body: |
+            ✅ Compose Desktop(JVM) 빌드가 성공적으로 완료되었습니다!
+            아티팩트(1일 보관):  
+            ${{ github.server_url }}/${{ github.event.workflow_run.repository.full_name }}/actions/runs/${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Overview (Required)
- Desktop(JVM) 앱 build script 기능을 추가합니다.
  - 데스크톱 앱 빌드(현재)
  - develop-2025에 PR을 올리고 계속 푸시를 할 때마다 해당 PR에 빌드된 아티팩트 링크를 댓글에 작성
    - 아티팩트 유지기간 1일
  - develop-2025에 머지될 때 빌드를 해주고 아티팩트를 업로드
    - 아티팩트 유지기간 3일

아티팩트 유지기간은 추가 논의 필요합니다.
