### PR TITLE
[init-theme] 테마 초기화

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/droidknights/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/droidknights/app/MainActivity.kt
@@ -1,16 +1,38 @@
 package com.droidknights.app
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.view.WindowCompat
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge(
+            navigationBarStyle = SystemBarStyle.auto(
+                lightScrim = Color.TRANSPARENT,
+                darkScrim = Color.TRANSPARENT
+            )
+        )
 
         setContent {
+            val view = LocalView.current
+            val darkTheme = isSystemInDarkTheme()
+            SideEffect {
+                with(WindowCompat.getInsetsController(window, view)) {
+                    isAppearanceLightStatusBars = !darkTheme
+                    isAppearanceLightNavigationBars = !darkTheme
+                }
+            }
+
             App()
         }
     }

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/Scaffold.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/Scaffold.kt
@@ -1,0 +1,16 @@
+package com.droidknights.app.core.designsystem.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Scaffold(
+    content: @Composable (PaddingValues) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    androidx.compose.material3.Scaffold(
+        modifier = modifier,
+        content = content
+    )
+}

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/Scaffold.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/Scaffold.kt
@@ -6,8 +6,8 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun Scaffold(
-    content: @Composable (PaddingValues) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    content: @Composable (PaddingValues) -> Unit
 ) {
     androidx.compose.material3.Scaffold(
         modifier = modifier,

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Color.kt
@@ -2,5 +2,12 @@ package com.droidknights.app.core.designsystem.theme
 
 import androidx.compose.ui.graphics.Color
 
-// TODO Figma 보고 현행화 해야함
-val Blue01 = Color(0xFF215BF6)
+val Blue01 = Color(0xFF5180FF)
+val Blue02 = Color(0xFF215BF6)
+
+val White = Color(0xFFFFFFFF)
+val PaleGray = Color(0xFFF9F9F9)
+val LightGray = Color(0xFFDCDCDC)
+val DarkGray = Color(0xFF5E5E5E)
+val Black = Color(0xFF000000)
+val Graphite = Color(0xFF292929)

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.compositionLocalOf
 
 // Light/Dark 모두 컴포넌트 + 화면 추가에 따라 색상 추가해야함
 private val DarkColorScheme = darkColorScheme(
-    primary = Blue02,
+    primary = Blue01,
     onPrimary = White,
     background = Black,
     surface = Graphite,
@@ -20,7 +20,7 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Blue01,
+    primary = Blue02,
     onPrimary = White,
     background = PaleGray,
     surface = White,

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
@@ -48,3 +48,9 @@ fun KnightsTheme(
         )
     }
 }
+
+object KnightsTheme {
+    val typography: KnightsTypography
+        @Composable
+        get() = LocalTypography.current
+}

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
@@ -2,23 +2,49 @@ package com.droidknights.app.core.designsystem.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 
+// Light/Dark 모두 컴포넌트 + 화면 추가에 따라 색상 추가해야함
+private val DarkColorScheme = darkColorScheme(
+    primary = Blue02,
+    onPrimary = White,
+    background = Black,
+    surface = Graphite,
+    onSurface = White,
+    onSurfaceVariant = DarkGray,
+    surfaceContainer = Graphite,
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Blue01,
+    onPrimary = White,
+    background = PaleGray,
+    surface = White,
+    onSurface = Black,
+    onSurfaceVariant = LightGray,
+    surfaceContainer = White,
+)
+
 val LocalDarkTheme = compositionLocalOf { true }
 
-// TODO 테마 정립
 @Composable
 fun KnightsTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+
     CompositionLocalProvider(
         LocalDarkTheme provides darkTheme,
         LocalTypography provides Typography
     ) {
-        // TODO colorScheme
-        MaterialTheme(content = content)
+        MaterialTheme(
+            colorScheme = colorScheme,
+            content = content
+        )
     }
 }

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 
 // Light/Dark 모두 컴포넌트 + 화면 추가에 따라 색상 추가해야함
@@ -52,5 +53,6 @@ fun KnightsTheme(
 object KnightsTheme {
     val typography: KnightsTypography
         @Composable
+        @ReadOnlyComposable
         get() = LocalTypography.current
 }

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Typography.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Typography.kt
@@ -5,24 +5,230 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 
 private val SansSerifStyle = TextStyle(
     fontFamily = FontFamily.SansSerif,
     fontWeight = FontWeight.Normal,
 )
 
-// TODO Figma 보고 현행화 해야함
 @Immutable
 data class KnightsTypography(
-    val textStyle1: TextStyle
+    val displayLargeR: TextStyle,
+    val displayMediumR: TextStyle,
+    val displaySmallR: TextStyle,
+
+    val headlineLargeEB: TextStyle,
+    val headlineLargeSB: TextStyle,
+    val headlineLargeR: TextStyle,
+    val headlineMediumB: TextStyle,
+    val headlineMediumM: TextStyle,
+    val headlineMediumR: TextStyle,
+    val headlineSmallBL: TextStyle,
+    val headlineSmallM: TextStyle,
+    val headlineSmallR: TextStyle,
+
+    val titleLargeBL: TextStyle,
+    val titleLargeB: TextStyle,
+    val titleLargeM: TextStyle,
+    val titleLargeR: TextStyle,
+    val titleMediumBL: TextStyle,
+    val titleMediumB: TextStyle,
+    val titleMediumR: TextStyle,
+    val titleSmallB: TextStyle,
+    val titleSmallM: TextStyle,
+    val titleSmallM140: TextStyle,
+    val titleSmallR: TextStyle,
+    val titleSmallR140: TextStyle,
+
+    val labelLargeM: TextStyle,
+    val labelMediumR: TextStyle,
+    val labelSmallM: TextStyle,
+
+    val bodyLargeR: TextStyle,
+    val bodyMediumR: TextStyle,
+    val bodySmallR: TextStyle,
 )
 
 internal val Typography = KnightsTypography(
-    textStyle1 = SansSerifStyle
+    displayLargeR = SansSerifStyle.copy(
+        fontSize = 57.sp,
+        lineHeight = 64.sp,
+        letterSpacing = (-0.25).sp,
+    ),
+    displayMediumR = SansSerifStyle.copy(
+        fontSize = 45.sp,
+        lineHeight = 52.sp,
+    ),
+    displaySmallR = SansSerifStyle.copy(
+        fontSize = 36.sp,
+        lineHeight = 44.sp,
+    ),
+    headlineLargeEB = SansSerifStyle.copy(
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        fontWeight = FontWeight.ExtraBold,
+    ),
+    headlineLargeSB = SansSerifStyle.copy(
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    headlineLargeR = SansSerifStyle.copy(
+        fontSize = 32.sp,
+        lineHeight = 40.sp,
+    ),
+    headlineMediumB = SansSerifStyle.copy(
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        fontWeight = FontWeight.Bold,
+    ),
+    headlineMediumM = SansSerifStyle.copy(
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        fontWeight = FontWeight.Medium,
+    ),
+    headlineMediumR = SansSerifStyle.copy(
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+    ),
+    headlineSmallBL = SansSerifStyle.copy(
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        fontWeight = FontWeight.Black,
+        letterSpacing = (-0.2).sp,
+    ),
+    headlineSmallM = SansSerifStyle.copy(
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+        fontWeight = FontWeight.Medium,
+    ),
+    headlineSmallR = SansSerifStyle.copy(
+        fontSize = 24.sp,
+        lineHeight = 32.sp,
+    ),
+    titleLargeBL = SansSerifStyle.copy(
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        fontWeight = FontWeight.Black,
+    ),
+    titleLargeB = SansSerifStyle.copy(
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        fontWeight = FontWeight.Bold,
+    ),
+    titleLargeM = SansSerifStyle.copy(
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        fontWeight = FontWeight.Medium,
+    ),
+    titleLargeR = SansSerifStyle.copy(
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+    ),
+    titleMediumBL = SansSerifStyle.copy(
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        fontWeight = FontWeight.Black,
+    ),
+    titleMediumB = SansSerifStyle.copy(
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        fontWeight = FontWeight.Bold,
+    ),
+    titleMediumR = SansSerifStyle.copy(
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+    ),
+    titleSmallB = SansSerifStyle.copy(
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 0.25.sp,
+    ),
+    titleSmallM = SansSerifStyle.copy(
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        fontWeight = FontWeight.Medium,
+        letterSpacing = 0.25.sp,
+    ),
+    titleSmallM140 = SansSerifStyle.copy(
+        fontSize = 14.sp,
+        lineHeight = (19.6).sp,
+        fontWeight = FontWeight.Medium,
+        letterSpacing = (-0.2).sp,
+    ),
+    titleSmallR140 = SansSerifStyle.copy(
+        fontSize = 14.sp,
+        lineHeight = (19.6).sp,
+        letterSpacing = (-0.2).sp,
+    ),
+    titleSmallR = SansSerifStyle.copy(
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+    ),
+    labelLargeM = SansSerifStyle.copy(
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+        fontWeight = FontWeight.Medium,
+    ),
+    labelMediumR = SansSerifStyle.copy(
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+    ),
+    labelSmallM = SansSerifStyle.copy(
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        fontWeight = FontWeight.Medium,
+        letterSpacing = (-0.2).sp,
+    ),
+    bodyLargeR = SansSerifStyle.copy(
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp,
+    ),
+    bodyMediumR = SansSerifStyle.copy(
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.25.sp,
+    ),
+    bodySmallR = SansSerifStyle.copy(
+        fontSize = 12.sp,
+        lineHeight = 16.sp,
+    )
 )
 
 val LocalTypography = staticCompositionLocalOf {
     KnightsTypography(
-        textStyle1 = SansSerifStyle
+        labelSmallM = SansSerifStyle,
+        displayLargeR = SansSerifStyle,
+        displayMediumR = SansSerifStyle,
+        displaySmallR = SansSerifStyle,
+        headlineLargeEB = SansSerifStyle,
+        headlineLargeSB = SansSerifStyle,
+        headlineLargeR = SansSerifStyle,
+        headlineMediumB = SansSerifStyle,
+        headlineMediumM = SansSerifStyle,
+        headlineMediumR = SansSerifStyle,
+        headlineSmallBL = SansSerifStyle,
+        headlineSmallM = SansSerifStyle,
+        headlineSmallR = SansSerifStyle,
+        titleLargeBL = SansSerifStyle,
+        titleLargeB = SansSerifStyle,
+        titleLargeM = SansSerifStyle,
+        titleLargeR = SansSerifStyle,
+        titleMediumBL = SansSerifStyle,
+        titleMediumB = SansSerifStyle,
+        titleMediumR = SansSerifStyle,
+        titleSmallB = SansSerifStyle,
+        titleSmallM = SansSerifStyle,
+        titleSmallM140 = SansSerifStyle,
+        titleSmallR = SansSerifStyle,
+        titleSmallR140 = SansSerifStyle,
+        labelLargeM = SansSerifStyle,
+        labelMediumR = SansSerifStyle,
+        bodyLargeR = SansSerifStyle,
+        bodyMediumR = SansSerifStyle,
+        bodySmallR = SansSerifStyle,
     )
 }

--- a/feature/main/src/commonMain/kotlin/com/droidknights/app/feature/main/MainScreen.kt
+++ b/feature/main/src/commonMain/kotlin/com/droidknights/app/feature/main/MainScreen.kt
@@ -1,12 +1,21 @@
 package com.droidknights.app.feature.main
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.droidknights.app.core.designsystem.components.Scaffold
 import com.droidknights.app.feature.main.components.MainNavHost
 
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier
 ) {
-    MainNavHost(modifier)
+    Scaffold(
+        modifier = modifier,
+        content = { padding ->
+            MainNavHost(
+                modifier = Modifier.padding(padding)
+            )
+        }
+    )
 }


### PR DESCRIPTION
## Overview (Required)
- Material 
  - 컬러 스킴 임시 구현 (향후 스펙 변화에 따라 변경 가능)
  - MainScreen에 Scaffold 추가
    - MaterialTheme.colors.background에 따라 앱 배경 및 content color 변경
- Typography 추가
  - 2024 디자인 시스템 차용
- 안드로이드
  - 다크모드 변경에 따른 시스템 아이콘 컬러 변경 대응

## 이슈
- 데스크탑에서 다크 모드 변경에 앱이 반응하지 않는 [Known Issue](https://youtrack.jetbrains.com/issue/CMP-1986/isSystemInDarkTheme-should-dynamically-update-when-system-theme-is-changed)가 있음
  - 플랫폼 특성에 따른 것으로, 이를 이미 해결한 [라이브러리](https://github.com/kdroidFilter/Platform-Tools?tab=readme-ov-file#-dark-mode-detection-module)도 존재

## Screenshot
Before | After
:--: | :--:
![Screenshot_20250506_164003](https://github.com/user-attachments/assets/0ee03713-894f-4c74-a801-9b9bc10afe03)| ![Screenshot_20250506_163953](https://github.com/user-attachments/assets/c455dbc6-992a-44fb-8a9c-33676938e047)


