### PR TITLE
[rename-cmp-branch] 브랜치 이름 변경에 따른 Github Action 설정 파일 대응

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -5,7 +5,7 @@ name: Android Build
 on:
   push:
     branches:
-      - develop-2025
+      - 2025/compose-multiplatform
   pull_request:
     paths-ignore:
       - 'iosApp/**'

--- a/.github/workflows/ios-arm-build.yml
+++ b/.github/workflows/ios-arm-build.yml
@@ -3,7 +3,7 @@ name: iOS Arm(Apple Silicon) Build
 on:
   push:
     branches:
-      - develop-2025
+      - 2025/compose-multiplatform
   pull_request:
 
 concurrency:

--- a/.github/workflows/ios-intel-build.yml
+++ b/.github/workflows/ios-intel-build.yml
@@ -3,7 +3,7 @@ name: iOS x64(Intel) Build
 on:
   push:
     branches:
-      - develop-2025
+      - 2025/compose-multiplatform
   pull_request:
 
 concurrency:

--- a/.github/workflows/jvm-desktop-build.yml
+++ b/.github/workflows/jvm-desktop-build.yml
@@ -3,12 +3,12 @@ name: Compose Desktop(JVM) CI
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ develop-2025 ]
+    branches: [ 2025/compose-multiplatform ]
     paths-ignore:
       - 'iosApp/**'
       - 'kotlin-js-store/**'
   push:
-    branches: [ develop-2025 ]
+    branches: [ 2025/compose-multiplatform ]
     paths-ignore:
       - 'iosApp/**'
       - 'kotlin-js-store/**'
@@ -46,7 +46,7 @@ jobs:
           path: composeApp/build/libs/*.jar
           retention-days: 1
 
-      - name: Upload artifact for develop-2025
+      - name: Upload artifact for 2025/compose-multiplatform
         if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -3,7 +3,7 @@ name: Compose Wasm(Web) Build
 on:
   push:
     branches:
-      - develop-2025
+      - 2025/compose-multiplatform
   pull_request:
     paths-ignore:
       - 'iosApp/**'

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -4,7 +4,7 @@ name: Publish Wasm App on GitHub Pages
 on:
   push:
     branches:
-      - develop-2025
+      - 2025/compose-multiplatform
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Overview (Required)
- 빌드 트리거의 branch 이름을 `2025/compose-multiplatform`으로 변경
