### PR TITLE
(FEAT)[#371] 내부용 BuildConfig 별도 모듈 추가

### DIFF
--- a/app-config/app-config-api/build.gradle.kts
+++ b/app-config/app-config-api/build.gradle.kts
@@ -1,0 +1,7 @@
+import com.droidknights.app.setNamespace
+
+plugins {
+    alias(libs.plugins.droidknights.android.library)
+}
+
+setNamespace("config.api")

--- a/app-config/app-config-api/src/main/AndroidManifest.xml
+++ b/app-config/app-config-api/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/app-config/app-config-api/src/main/java/com/droidknights/app/config/api/DroidknightsBuildConfig.kt
+++ b/app-config/app-config-api/src/main/java/com/droidknights/app/config/api/DroidknightsBuildConfig.kt
@@ -1,0 +1,6 @@
+package com.droidknights.app.config.api
+
+interface DroidknightsBuildConfig {
+
+    fun isDebug(): Boolean
+}

--- a/app-config/app-config/build.gradle.kts
+++ b/app-config/app-config/build.gradle.kts
@@ -1,0 +1,13 @@
+import com.droidknights.app.configureBuildConfig
+import com.droidknights.app.setNamespace
+
+plugins {
+    alias(libs.plugins.droidknights.android.library)
+}
+
+setNamespace("app.config")
+configureBuildConfig()
+
+dependencies {
+    implementation(projects.appConfig.appConfigApi)
+}

--- a/app-config/app-config/src/main/AndroidManifest.xml
+++ b/app-config/app-config/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/app-config/app-config/src/main/java/com/droidknights/app/config/DroidknightsBuildConfigImpl.kt
+++ b/app-config/app-config/src/main/java/com/droidknights/app/config/DroidknightsBuildConfigImpl.kt
@@ -1,0 +1,13 @@
+package com.droidknights.app.config
+
+import com.droidknights.app.app.config.BuildConfig
+import com.droidknights.app.config.api.DroidknightsBuildConfig
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class DroidknightsBuildConfigImpl @Inject constructor() : DroidknightsBuildConfig {
+
+    override fun isDebug(): Boolean =
+        BuildConfig.DEBUG
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,8 @@ android {
 dependencies {
     implementation(projects.core.network.network)
     implementation(projects.core.network.networkApi)
+    implementation(projects.appConfig.appConfig)
+    implementation(projects.appConfig.appConfigApi)
 
     implementation(projects.core.navigation)
     implementation(projects.feature.main)

--- a/build-logic/convention/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/droidknights/app/KotlinAndroid.kt
@@ -11,6 +11,14 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
+fun Project.configureBuildConfig() {
+    androidExtension.apply {
+        buildFeatures {
+            buildConfig = true
+        }
+    }
+}
+
 /**
  * https://github.com/android/nowinandroid/blob/main/build-logic/convention/src/main/kotlin/com/google/samples/apps/nowinandroid/KotlinAndroid.kt
  */
@@ -45,6 +53,9 @@ internal fun Project.configureKotlinAndroid() {
             unitTests {
                 isIncludeAndroidResources = true
             }
+        }
+        buildFeatures {
+            buildConfig = false
         }
     }
 

--- a/core/network/network/build.gradle.kts
+++ b/core/network/network/build.gradle.kts
@@ -10,6 +10,7 @@ setNamespace("core.network")
 
 dependencies {
     implementation(projects.core.network.networkApi)
+    implementation(projects.appConfig.appConfigApi)
 
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)

--- a/core/network/network/src/main/java/com/droidknights/app/core/network/di/NetworkModule.kt
+++ b/core/network/network/src/main/java/com/droidknights/app/core/network/di/NetworkModule.kt
@@ -1,17 +1,23 @@
 package com.droidknights.app.core.network.di
 
+import android.util.Log
+import com.droidknights.app.config.api.DroidknightsBuildConfig
 import com.droidknights.app.core.network.DroidknightsNetworkImpl
 import com.droidknights.app.core.network.api.DroidknightsNetwork
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
 import kotlinx.serialization.json.Json
+import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module
@@ -20,8 +26,28 @@ internal object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkhttpClient(): OkHttpClient =
-        OkHttpClient.Builder().build()
+    fun provideOkhttpClient(
+        interceptors: Provider<Set<@JvmSuppressWildcards Interceptor>>,
+    ): OkHttpClient =
+        OkHttpClient.Builder()
+            .apply {
+                interceptors.get().forEach { addInterceptor(it) }
+            }
+            .build()
+
+    @Provides
+    @Singleton
+    @IntoSet
+    fun providerHttpLoggingInterceptor(
+        droidknightsBuildConfig: DroidknightsBuildConfig,
+    ): Interceptor =
+        HttpLoggingInterceptor {
+            if (droidknightsBuildConfig.isDebug()) {
+                Log.d("Droidknights", it)
+            }
+        }.apply {
+            setLevel(HttpLoggingInterceptor.Level.BODY)
+        }
 
     @Provides
     @Singleton

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,11 @@ rootProject.name = "DroidKnights"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include(":app")
 
+include(
+    ":app-config:app-config-api",
+    ":app-config:app-config",
+)
+
 // Baseline Profile
 include(":baselineprofile")
 


### PR DESCRIPTION
## Issue
- close #371

## Overview (Required)
- BuildConfig를 모두 false 처리
- 특정 모듈에서만 BuildConfig 활용할 수 있도록 옵션 추가
- App내 BuildConfig 관리용 모듈 추가
- App BuildConfig를 활용하여 api 모듈만 바라보도록 적용
