### PR TITLE
(BUG)[#393] 2025 앱 CI 테스트 실패 문제를 해결

### DIFF
--- a/.github/workflows/android-pull-request-ci.yml
+++ b/.github/workflows/android-pull-request-ci.yml
@@ -2,7 +2,9 @@ name: Android Pull Request CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - 2025/app # TODO 개발기간 중 임시로 추가. 나중에 제거 필요
 
 jobs:
   verify:

--- a/core/data/data-session/src/test/java/com/droidknights/app/core/data/session/fake/FakeSessionPreferencesDataSource.kt
+++ b/core/data/data-session/src/test/java/com/droidknights/app/core/data/session/fake/FakeSessionPreferencesDataSource.kt
@@ -1,6 +1,6 @@
 package com.droidknights.app.core.data.session.fake
 
-import com.droidknights.app.core.datastore.datasource.SessionPreferencesDataSource
+import com.droidknights.app.core.datastore.session.api.SessionPreferencesDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull

--- a/core/data/data-settings/src/test/java/com/droidknights/app/core/data/settings/SettingsRepositoryImplTest.kt
+++ b/core/data/data-settings/src/test/java/com/droidknights/app/core/data/settings/SettingsRepositoryImplTest.kt
@@ -1,8 +1,7 @@
 package com.droidknights.app.core.data.settings
 
 import app.cash.turbine.test
-import com.droidknights.app.core.datastore.datasource.SettingsPreferencesDataSource
-import com.droidknights.app.core.datastore.model.SettingsData
+import com.droidknights.app.core.datastore.settings.api.SettingsPreferencesDataSource
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -21,14 +20,14 @@ class SettingsRepositoryImplTest {
 
     @Test
     fun `test flowIsDarkTheme`() = runTest {
-        whenever(settingsPreferencesDataSource.settingsData).thenReturn(flowOf(SettingsData(isDarkTheme = true)))
+        whenever(settingsPreferencesDataSource.isDarkThemeFlow).thenReturn(flowOf(true))
 
         repository.flowIsDarkTheme().test {
             val result = awaitItem()
 
             assertTrue(result)
 
-            verify(settingsPreferencesDataSource).settingsData
+            verify(settingsPreferencesDataSource).isDarkThemeFlow
 
             cancelAndIgnoreRemainingEvents()
         }

--- a/core/network/network/src/test/java/com/droidknights/app/core/network/MockDroidknightsService.kt
+++ b/core/network/network/src/test/java/com/droidknights/app/core/network/MockDroidknightsService.kt
@@ -1,3 +1,3 @@
 package com.droidknights.app.core.network
 
-internal object MockDroidknightsService
+internal interface MockDroidknightsService

--- a/feature/contributor/src/androidTest/java/com/droidknights/app/feature/contributor/ContributorScreenTest.kt
+++ b/feature/contributor/src/androidTest/java/com/droidknights/app/feature/contributor/ContributorScreenTest.kt
@@ -41,7 +41,8 @@ class ContributorScreenTest {
         // when
         fakeUiState.value = ContributorsUiState.Contributors(
             persistentListOf(
-                Contributor(
+                ContributorsUiState.Contributors.Item.User(
+                    id = 1L,
                     name = "test name",
                     imageUrl = "test image url",
                     githubUrl = "test github url"

--- a/feature/home/src/test/java/com/droidknights/app/feature/home/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/droidknights/app/feature/home/HomeViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.droidknights.app.feature.home
 
 import app.cash.turbine.test
+import com.droidknights.app.core.domain.sponsor.usecase.api.GetSponsorsUseCase
 import com.droidknights.app.core.model.sponsor.Sponsor
 import com.droidknights.app.core.testing.rule.MainDispatcherRule
 import com.droidknights.app.feature.home.model.SponsorsUiState


### PR DESCRIPTION
## Issue
- close #393

## Overview (Required)
- 모듈을 쪼개면서 변경된 점들이 테스트 코드에 반영되지 않아 테스트가 실패하고 있었음. 코드 현행화를 통해 정상 동작하도록 수정
- (임시) 2025/app을 타겟으로 하는 pr에도 pr ci가 돌도록 수정
