### PR TITLE
[wasm-korean] 한글 폰트 사용 + preload로 웹에서 한글 꺠짐 문제 해결

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/droidknights/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/droidknights/app/App.kt
@@ -3,11 +3,15 @@ package com.droidknights.app
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.text.font.FontFamily
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.droidknights.app.core.data.setting.di.coreDataSettingModule
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
 import com.droidknights.app.feature.main.MainScreen
 import com.droidknights.app.feature.setting.di.featureSettingModule
+import droidknights.composeapp.generated.resources.NotoSans
+import droidknights.composeapp.generated.resources.Res
+import org.jetbrains.compose.resources.Font
 import org.koin.compose.KoinApplication
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.module.dsl.viewModelOf
@@ -17,6 +21,7 @@ import org.koin.dsl.module
 @Composable
 internal fun App(
     onDarkThemeChange: ((Boolean) -> Unit)? = null,
+    fontFamily: FontFamily = FontFamily(Font(resource = Res.font.NotoSans)),
 ) {
     KoinApplication(
         application = koinAppDeclaration,
@@ -28,7 +33,10 @@ internal fun App(
             LaunchedEffect(appUiState.isDarkTheme) { onDarkThemeChange(appUiState.isDarkTheme) }
         }
 
-        KnightsTheme(darkTheme = appUiState.isDarkTheme) {
+        KnightsTheme(
+            darkTheme = appUiState.isDarkTheme,
+            fontFamily = fontFamily,
+        ) {
             MainScreen()
         }
     }

--- a/composeApp/src/wasmJsMain/kotlin/com/droidknights/app/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/droidknights/app/main.kt
@@ -2,13 +2,23 @@
 
 package com.droidknights.app
 
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.window.ComposeViewport
+import droidknights.composeapp.generated.resources.NotoSans
+import droidknights.composeapp.generated.resources.Res
 import kotlinx.browser.document
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.preloadFont
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalResourceApi::class)
 fun main() {
     ComposeViewport(document.body!!) {
-        App()
+        val font by preloadFont(Res.font.NotoSans)
+
+        font?.let {
+            App(fontFamily = FontFamily(it))
+        }
     }
 }

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Theme.kt
@@ -7,11 +7,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.text.font.FontFamily
 
 val LocalDarkTheme = compositionLocalOf { true }
 
 @Composable
 fun KnightsTheme(
+    fontFamily: FontFamily = FontFamily.Default,
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
@@ -23,7 +25,7 @@ fun KnightsTheme(
             KnightsColorScheme.lightColorScheme
         },
         LocalIndication provides ripple(),
-        LocalTypography provides Typography,
+        LocalTypography provides KnightsTypography.with(fontFamily),
         content = content,
     )
 }

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Typography.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/theme/Typography.kt
@@ -7,228 +7,173 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-private val SansSerifStyle = TextStyle(
-    fontFamily = FontFamily.SansSerif,
-    fontWeight = FontWeight.Normal,
-)
-
 @Immutable
 data class KnightsTypography(
-    val displayLargeR: TextStyle,
-    val displayMediumR: TextStyle,
-    val displaySmallR: TextStyle,
+    val default: TextStyle,
 
-    val headlineLargeEB: TextStyle,
-    val headlineLargeSB: TextStyle,
-    val headlineLargeR: TextStyle,
-    val headlineMediumB: TextStyle,
-    val headlineMediumM: TextStyle,
-    val headlineMediumR: TextStyle,
-    val headlineSmallBL: TextStyle,
-    val headlineSmallM: TextStyle,
-    val headlineSmallR: TextStyle,
-
-    val titleLargeBL: TextStyle,
-    val titleLargeB: TextStyle,
-    val titleLargeM: TextStyle,
-    val titleLargeR: TextStyle,
-    val titleMediumBL: TextStyle,
-    val titleMediumB: TextStyle,
-    val titleMediumR: TextStyle,
-    val titleSmallB: TextStyle,
-    val titleSmallM: TextStyle,
-    val titleSmallM140: TextStyle,
-    val titleSmallR: TextStyle,
-    val titleSmallR140: TextStyle,
-
-    val labelLargeM: TextStyle,
-    val labelMediumR: TextStyle,
-    val labelSmallM: TextStyle,
-
-    val bodyLargeR: TextStyle,
-    val bodyMediumR: TextStyle,
-    val bodySmallR: TextStyle,
-)
-
-internal val Typography = KnightsTypography(
-    displayLargeR = SansSerifStyle.copy(
+    val displayLargeR: TextStyle = default.copy(
         fontSize = 57.sp,
         lineHeight = 64.sp,
         letterSpacing = (-0.25).sp,
     ),
-    displayMediumR = SansSerifStyle.copy(
+    val displayMediumR: TextStyle = default.copy(
         fontSize = 45.sp,
         lineHeight = 52.sp,
     ),
-    displaySmallR = SansSerifStyle.copy(
+    val displaySmallR: TextStyle = default.copy(
         fontSize = 36.sp,
         lineHeight = 44.sp,
     ),
-    headlineLargeEB = SansSerifStyle.copy(
+
+    val headlineLargeEB: TextStyle = default.copy(
         fontSize = 32.sp,
         lineHeight = 40.sp,
         fontWeight = FontWeight.ExtraBold,
     ),
-    headlineLargeSB = SansSerifStyle.copy(
+    val headlineLargeSB: TextStyle = default.copy(
         fontSize = 32.sp,
         lineHeight = 40.sp,
         fontWeight = FontWeight.SemiBold,
     ),
-    headlineLargeR = SansSerifStyle.copy(
+    val headlineLargeR: TextStyle = default.copy(
         fontSize = 32.sp,
         lineHeight = 40.sp,
     ),
-    headlineMediumB = SansSerifStyle.copy(
+    val headlineMediumB: TextStyle = default.copy(
         fontSize = 28.sp,
         lineHeight = 36.sp,
         fontWeight = FontWeight.Bold,
     ),
-    headlineMediumM = SansSerifStyle.copy(
+    val headlineMediumM: TextStyle = default.copy(
         fontSize = 28.sp,
         lineHeight = 36.sp,
         fontWeight = FontWeight.Medium,
     ),
-    headlineMediumR = SansSerifStyle.copy(
+    val headlineMediumR: TextStyle = default.copy(
         fontSize = 28.sp,
         lineHeight = 36.sp,
     ),
-    headlineSmallBL = SansSerifStyle.copy(
+    val headlineSmallBL: TextStyle = default.copy(
         fontSize = 24.sp,
         lineHeight = 32.sp,
         fontWeight = FontWeight.Black,
         letterSpacing = (-0.2).sp,
     ),
-    headlineSmallM = SansSerifStyle.copy(
+    val headlineSmallM: TextStyle = default.copy(
         fontSize = 24.sp,
         lineHeight = 32.sp,
         fontWeight = FontWeight.Medium,
     ),
-    headlineSmallR = SansSerifStyle.copy(
+    val headlineSmallR: TextStyle = default.copy(
         fontSize = 24.sp,
         lineHeight = 32.sp,
     ),
-    titleLargeBL = SansSerifStyle.copy(
+
+    val titleLargeBL: TextStyle = default.copy(
         fontSize = 22.sp,
         lineHeight = 28.sp,
         fontWeight = FontWeight.Black,
     ),
-    titleLargeB = SansSerifStyle.copy(
+    val titleLargeB: TextStyle = default.copy(
         fontSize = 22.sp,
         lineHeight = 28.sp,
         fontWeight = FontWeight.Bold,
     ),
-    titleLargeM = SansSerifStyle.copy(
+    val titleLargeM: TextStyle = default.copy(
         fontSize = 22.sp,
         lineHeight = 28.sp,
         fontWeight = FontWeight.Medium,
     ),
-    titleLargeR = SansSerifStyle.copy(
+    val titleLargeR: TextStyle = default.copy(
         fontSize = 22.sp,
         lineHeight = 28.sp,
     ),
-    titleMediumBL = SansSerifStyle.copy(
+    val titleMediumBL: TextStyle = default.copy(
         fontSize = 16.sp,
         lineHeight = 24.sp,
         fontWeight = FontWeight.Black,
     ),
-    titleMediumB = SansSerifStyle.copy(
+    val titleMediumB: TextStyle = default.copy(
         fontSize = 16.sp,
         lineHeight = 24.sp,
         fontWeight = FontWeight.Bold,
     ),
-    titleMediumR = SansSerifStyle.copy(
+    val titleMediumR: TextStyle = default.copy(
         fontSize = 16.sp,
         lineHeight = 24.sp,
     ),
-    titleSmallB = SansSerifStyle.copy(
+    val titleSmallB: TextStyle = default.copy(
         fontSize = 14.sp,
         lineHeight = 20.sp,
         fontWeight = FontWeight.Bold,
         letterSpacing = 0.25.sp,
     ),
-    titleSmallM = SansSerifStyle.copy(
+    val titleSmallM: TextStyle = default.copy(
         fontSize = 14.sp,
         lineHeight = 20.sp,
         fontWeight = FontWeight.Medium,
         letterSpacing = 0.25.sp,
     ),
-    titleSmallM140 = SansSerifStyle.copy(
+    val titleSmallM140: TextStyle = default.copy(
         fontSize = 14.sp,
         lineHeight = (19.6).sp,
         fontWeight = FontWeight.Medium,
         letterSpacing = (-0.2).sp,
     ),
-    titleSmallR140 = SansSerifStyle.copy(
-        fontSize = 14.sp,
-        lineHeight = (19.6).sp,
-        letterSpacing = (-0.2).sp,
-    ),
-    titleSmallR = SansSerifStyle.copy(
+    val titleSmallR: TextStyle = default.copy(
         fontSize = 14.sp,
         lineHeight = 20.sp,
     ),
-    labelLargeM = SansSerifStyle.copy(
+    val titleSmallR140: TextStyle = default.copy(
+        fontSize = 14.sp,
+        lineHeight = (19.6).sp,
+        letterSpacing = (-0.2).sp,
+    ),
+
+    val labelLargeM: TextStyle = default.copy(
         fontSize = 12.sp,
         lineHeight = 16.sp,
         fontWeight = FontWeight.Medium,
     ),
-    labelMediumR = SansSerifStyle.copy(
+    val labelMediumR: TextStyle = default.copy(
         fontSize = 12.sp,
         lineHeight = 16.sp,
     ),
-    labelSmallM = SansSerifStyle.copy(
+    val labelSmallM: TextStyle = default.copy(
         fontSize = 11.sp,
         lineHeight = 16.sp,
         fontWeight = FontWeight.Medium,
         letterSpacing = (-0.2).sp,
     ),
-    bodyLargeR = SansSerifStyle.copy(
+
+    val bodyLargeR: TextStyle = default.copy(
         fontSize = 16.sp,
         lineHeight = 24.sp,
         letterSpacing = 0.5.sp,
     ),
-    bodyMediumR = SansSerifStyle.copy(
+    val bodyMediumR: TextStyle = default.copy(
         fontSize = 14.sp,
         lineHeight = 20.sp,
         letterSpacing = 0.25.sp,
     ),
-    bodySmallR = SansSerifStyle.copy(
+    val bodySmallR: TextStyle = default.copy(
         fontSize = 12.sp,
         lineHeight = 16.sp,
     ),
-)
+) {
+    companion object {
+        fun with(
+            fontFamily: FontFamily = FontFamily.Default,
+            fontWeight: FontWeight = FontWeight.Normal,
+        ) = KnightsTypography(
+            default = TextStyle(
+                fontFamily = fontFamily,
+                fontWeight = fontWeight,
+            ),
+        )
+    }
+}
 
-val LocalTypography = staticCompositionLocalOf {
-    KnightsTypography(
-        labelSmallM = SansSerifStyle,
-        displayLargeR = SansSerifStyle,
-        displayMediumR = SansSerifStyle,
-        displaySmallR = SansSerifStyle,
-        headlineLargeEB = SansSerifStyle,
-        headlineLargeSB = SansSerifStyle,
-        headlineLargeR = SansSerifStyle,
-        headlineMediumB = SansSerifStyle,
-        headlineMediumM = SansSerifStyle,
-        headlineMediumR = SansSerifStyle,
-        headlineSmallBL = SansSerifStyle,
-        headlineSmallM = SansSerifStyle,
-        headlineSmallR = SansSerifStyle,
-        titleLargeBL = SansSerifStyle,
-        titleLargeB = SansSerifStyle,
-        titleLargeM = SansSerifStyle,
-        titleLargeR = SansSerifStyle,
-        titleMediumBL = SansSerifStyle,
-        titleMediumB = SansSerifStyle,
-        titleMediumR = SansSerifStyle,
-        titleSmallB = SansSerifStyle,
-        titleSmallM = SansSerifStyle,
-        titleSmallM140 = SansSerifStyle,
-        titleSmallR = SansSerifStyle,
-        titleSmallR140 = SansSerifStyle,
-        labelLargeM = SansSerifStyle,
-        labelMediumR = SansSerifStyle,
-        bodyLargeR = SansSerifStyle,
-        bodyMediumR = SansSerifStyle,
-        bodySmallR = SansSerifStyle,
-    )
+internal val LocalTypography = staticCompositionLocalOf<KnightsTypography> {
+    error("KnightsTypography를 provide 해야합니다.")
 }


### PR DESCRIPTION
## Issue
- close #367 

## Overview (Required)
- 한글 폰트를 사용하여 한글 깨짐 문제 해결
- wasm에서 font를 초기에 불러오지 못하는 문제가 있어서 preloadFont를 사용함

## Links
- https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-resources-usage.html#preload-resources-using-the-compose-multiplatform-preload-api

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a29f73e0-6824-49aa-8c21-8f4a8956a382" width="300" /> | <img src="https://github.com/user-attachments/assets/8c3db45e-3455-49f3-ba6e-beb69a55d63c" width="300" />
