### PR TITLE
(ENG)[droidknights#438] Network 객체 생성시 명시적 클래스 선언을 inline-reified 로 변경

### DIFF
--- a/core/data/data-contributor/src/main/java/com/droidknights/app/core/data/contributor/di/ApiModule.kt
+++ b/core/data/data-contributor/src/main/java/com/droidknights/app/core/data/contributor/di/ApiModule.kt
@@ -6,6 +6,7 @@ import com.droidknights.app.core.data.contributor.api.DroidnightsContributorsApi
 import com.droidknights.app.core.data.contributor.api.GithubContributorsApi
 import com.droidknights.app.core.data.contributor.api.fake.AssetsDroidnightsContributorsApi
 import com.droidknights.app.core.network.api.DroidknightsNetwork
+import com.droidknights.app.core.network.api.create
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,9 +26,8 @@ internal object ApiModule {
         droidknightsBuildConfig: DroidknightsBuildConfig,
     ): GithubContributorsApi =
         droidknightsNetwork
-            .create(
+            .create<GithubContributorsApi>(
                 baseUrl = droidknightsBuildConfig.gitHubUrl(),
-                service = GithubContributorsApi::class.java,
             )
 
     @Provides
@@ -37,9 +37,8 @@ internal object ApiModule {
         droidknightsBuildConfig: DroidknightsBuildConfig,
     ): DroidnightsContributorsApi =
         droidknightsNetwork
-            .create(
+            .create<DroidnightsContributorsApi>(
                 baseUrl = droidknightsBuildConfig.userDroidknightsUrl(),
-                service = DroidnightsContributorsApi::class.java,
             )
 
     @Provides

--- a/core/data/data-session/src/main/java/com/droidknights/app/core/data/session/di/ApiModule.kt
+++ b/core/data/data-session/src/main/java/com/droidknights/app/core/data/session/di/ApiModule.kt
@@ -22,6 +22,6 @@ internal object ApiModule {
     ): SessionApi =
         droidknightsNetwork
             .create<SessionApi>(
-                baseUrl = droidknightsBuildConfig.userDroidknightsUrl(),
+                baseUrl = droidknightsBuildConfig.userDroidknightsUrl()
             )
 }

--- a/core/data/data-session/src/main/java/com/droidknights/app/core/data/session/di/ApiModule.kt
+++ b/core/data/data-session/src/main/java/com/droidknights/app/core/data/session/di/ApiModule.kt
@@ -3,6 +3,7 @@ package com.droidknights.app.core.data.session.di
 import com.droidknights.app.config.api.DroidknightsBuildConfig
 import com.droidknights.app.core.data.session.api.SessionApi
 import com.droidknights.app.core.network.api.DroidknightsNetwork
+import com.droidknights.app.core.network.api.create
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,8 +21,7 @@ internal object ApiModule {
         droidknightsBuildConfig: DroidknightsBuildConfig,
     ): SessionApi =
         droidknightsNetwork
-            .create(
+            .create<SessionApi>(
                 baseUrl = droidknightsBuildConfig.userDroidknightsUrl(),
-                service = SessionApi::class.java,
             )
 }

--- a/core/data/data-sponsor/src/main/java/com/droidknights/app/core/data/sponsor/di/ApiModule.kt
+++ b/core/data/data-sponsor/src/main/java/com/droidknights/app/core/data/sponsor/di/ApiModule.kt
@@ -3,6 +3,7 @@ package com.droidknights.app.core.data.sponsor.di
 import com.droidknights.app.config.api.DroidknightsBuildConfig
 import com.droidknights.app.core.data.sponsor.api.SponsorApi
 import com.droidknights.app.core.network.api.DroidknightsNetwork
+import com.droidknights.app.core.network.api.create
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,8 +21,7 @@ internal object ApiModule {
         droidknightsBuildConfig: DroidknightsBuildConfig,
     ): SponsorApi =
         droidknightsNetwork
-            .create(
+            .create<SponsorApi>(
                 baseUrl = droidknightsBuildConfig.userDroidknightsUrl(),
-                service = SponsorApi::class.java,
             )
 }

--- a/core/network/network-api/src/main/java/com/droidknights/app/core/network/api/DroidknightsNetwork.kt
+++ b/core/network/network-api/src/main/java/com/droidknights/app/core/network/api/DroidknightsNetwork.kt
@@ -4,3 +4,7 @@ interface DroidknightsNetwork {
 
     fun <T> create(baseUrl: String, service: Class<T>): T
 }
+
+inline fun <reified T> DroidknightsNetwork.create(baseUrl: String): T {
+    return create(baseUrl, T::class.java)
+}

--- a/core/network/network/src/test/java/com/droidknights/app/core/network/DroidknightsNetworkImplTest.kt
+++ b/core/network/network/src/test/java/com/droidknights/app/core/network/DroidknightsNetworkImplTest.kt
@@ -1,5 +1,6 @@
 package com.droidknights.app.core.network
 
+import com.droidknights.app.core.network.api.create
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -14,6 +15,6 @@ internal class DroidknightsNetworkImplTest {
 
     @Test
     fun `test create`() = runTest {
-        Assertions.assertNotNull(network.create("https://droidknihghts.app/", MockDroidknightsService::class.java))
+        Assertions.assertNotNull(network.create<MockDroidknightsService>("https://droidknihghts.app/"))
     }
 }


### PR DESCRIPTION
## Issue
- #438

## Overview (Required)
|-|-|
|----|----|
|before|droidknightsNetwork.create(<br>&nbsp;&nbsp;&nbsp;&nbsp;baseUrl = droidknightsBuildConfig.userDroidknightsUrl(),    <br>&nbsp;&nbsp;&nbsp;&nbsp;service = DroidnightsContributorsApi::class.java<br>)|
|after|droidknightsNetwork.create\<DroidnightsContributorsApi\>(<br>&nbsp;&nbsp;&nbsp;&nbsp;baseUrl = droidknightsBuildConfig.userDroidknightsUrl()<br>)|