### PR TITLE
[#366] Fix shader issue on Non-Android target

### DIFF
--- a/core/ui/shader/src/commonMain/kotlin/com/droidknights/app/core/shader/components/ShaderBackground.kt
+++ b/core/ui/shader/src/commonMain/kotlin/com/droidknights/app/core/shader/components/ShaderBackground.kt
@@ -18,11 +18,10 @@ internal fun ShaderBackground(
         modifier = modifier
             .drawWithCache {
                 val runtimeEffect = buildEffect(shader)
-                val brush = runtimeEffect.build()
 
                 onDrawBehind {
                     runtimeEffect.update(shader, size.width, size.height)
-                    drawRect(brush = brush)
+                    drawRect(brush = runtimeEffect.build())
                 }
             },
         content = content,

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -11,8 +11,7 @@ kotlin {
             implementation(libs.androidx.navigation.compose)
             implementation(projects.core.designsystem)
             implementation(projects.core.navigation)
-            // TODO 카드 배경 png 말고 shader로 구현 해보기
-//            implementation(projects.core.ui.shader)
+            implementation(projects.core.ui.shader)
         }
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeSessionCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeSessionCard.kt
@@ -1,25 +1,21 @@
 package com.droidknights.app.feature.home.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.droidknights.app.core.designsystem.components.Surface
 import com.droidknights.app.core.designsystem.components.Text
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
 import com.droidknights.app.core.designsystem.theme.LocalContentColor
+import com.droidknights.app.core.shader.components.BottomUpGlowBackground
 import droidknights.feature.home.generated.resources.Res
-import droidknights.feature.home.generated.resources.background_home_session_card
 import droidknights.feature.home.generated.resources.home_session_card_desc
 import droidknights.feature.home.generated.resources.home_session_card_title
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -34,13 +30,7 @@ fun HomeSessionCard(
         color = KnightsTheme.colorScheme.primary,
         shape = RoundedCornerShape(16.dp),
     ) {
-        Box {
-            Image(
-                modifier = Modifier.matchParentSize(),
-                painter = painterResource(Res.drawable.background_home_session_card),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-            )
+        BottomUpGlowBackground {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
## Issue
- Non-Android 타겟에서 Shader가 정상적으로 노출되지 않는 케이스 수정 
- fix #366

## Overview (Required)
기존 코드는 runtimeEffect에 대해서 early build를 수행하고 있었기에, shader에 필요한 해상도(`uResolution`)에 올바른 값을 전달하지 못하고 있었습니다.
이로 인해, Non-Android 타겟에서 Shader의 시작위치를 제대로 반영하지 못하고 있어서 랜더링 이슈가 발생한 것으로 확인했습니다.

이번 PR에서 Draw 영역의 실제 사이즈를 측정한 이후,
정확한 값을 shader의 uniform에 전달하고 runtimeEffect를 build하도록 수정하였습니다.

아래와 같이, 정확한 사이즈를 update한 뒤 build를 수행하면 문제가 해결됩니다.
```kotlin
.drawWithCache {
    val runtimeEffect = buildEffect(shader)

    onDrawBehind {
        runtimeEffect.update(shader, size.width, size.height)
        drawRect(brush = runtimeEffect.build())
    }
},
```

확인 부탁드리겠습니다.

## Screenshot
<img src="https://github.com/user-attachments/assets/b70d9e23-894a-45cc-bf78-ebd2b760ee91" width="1000" />
