### PR TITLE
(FEAT)/#418: Compose Hot-reload 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
+    alias(libs.plugins.composeHotReload) apply false
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinxSerialization) apply false

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,9 +1,11 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     alias(libs.plugins.androidApplication)
+    alias(libs.plugins.composeHotReload)
     id("droidknights.kotlin.multiplatform")
     id("droidknights.compose.multiplatform")
 }
@@ -60,6 +62,10 @@ kotlin {
             implementation(libs.kotlinx.coroutines.swing)
         }
     }
+}
+
+composeCompiler {
+    featureFlags.add(ComposeFeatureFlag.OptimizeNonSkippingGroups)
 }
 
 android {

--- a/composeApp/src/desktopMain/kotlin/com/droidknights/app/main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/droidknights/app/main.kt
@@ -2,14 +2,10 @@
 
 package com.droidknights.app
 
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.application
+import androidx.compose.ui.window.singleWindowApplication
 
-fun main() = application {
-    Window(
-        onCloseRequest = ::exitApplication,
-        title = "DroidKnights",
-    ) {
-        App()
-    }
+fun main() = singleWindowApplication(
+    title = "DroidKnights",
+) {
+    App()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ logback = "1.5.18"
 detekt = "1.23.8"
 twitterComposeRule = "0.0.26"
 coil = "3.2.0"
+composeHotReload = "1.0.0-alpha10"
 
 [libraries]
 # Kotlin
@@ -87,6 +88,7 @@ detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gr
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         google {


### PR DESCRIPTION
## Issue
- close #418 

## Overview (Required)
<img width="955" alt="image" src="https://github.com/user-attachments/assets/bf49c95f-22f6-4568-8f72-0ea4d7e536d0" />
- compose-hot-reload의 가장 최신 버전인 1.0.0-alpha10을 적용했습니다.

## Links
- https://github.com/JetBrains/compose-hot-reload

## Screenshot
https://github.com/user-attachments/assets/f614a16d-4aba-41d1-a240-4812f734d116




