### PR TITLE
Updates AndroidX May 20, 2025

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidxLifecycle = "2.9.0"
 # https://developer.android.com/jetpack/androidx/releases/activity
 androidxActivity = "1.10.1"
 # https://developer.android.com/jetpack/androidx/releases/datastore
-androidxDatastore = "1.1.6"
+androidxDatastore = "1.1.7"
 # https://developer.android.com/jetpack/androidx/releases/glance
 androidxGlance = "1.1.1"
 glanceExperimentalTools = "0.2.2"
@@ -26,7 +26,7 @@ baselineprofile = "1.3.4"
 
 ## Compose
 # https://developer.android.com/develop/ui/compose/bom/bom-mapping
-androidxComposeBom = "2025.05.00"
+androidxComposeBom = "2025.05.01"
 # https://developer.android.com/jetpack/androidx/releases/navigation
 androidxComposeNavigation = "2.9.0"
 # https://developer.android.com/jetpack/androidx/releases/compose-material3
@@ -81,7 +81,6 @@ ossLicensesPlugin = "0.10.6"
 junit4 = "4.13.2"
 # https://mvnrepository.com/artifact/org.junit.vintage/junit-vintage-engine
 junitVintageEngine = "5.12.2"
-ui-test-junit4 = "1.8.1"
 # https://developer.android.com/jetpack/androidx/releases/test-uiautomator
 uiAutomator = "2.3.0"
 androidxTestRunner = "1.6.2"
@@ -110,7 +109,7 @@ test-mockito-kotlin = "5.4.0"
 # https://github.com/mannodermaus/android-junit5
 test-junit5-plugin = "1.12.0.0"
 # https://github.com/junit-team/junit5
-test-junit5 = "5.12.1"
+test-junit5 = "5.12.2"
 
 [libraries]
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
@@ -131,7 +130,7 @@ androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profi
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxComposeMaterial3" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
-androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "ui-test-junit4" }
+androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-testManifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
## Issue
- close #447

## Overview (Required)
- AndroidX 정식 버전 업데이트
- ui-test-junit4의 버전은 BOM에서 관리하는 것으로 보여서 제거 대응했습니다
  - https://developer.android.com/develop/ui/compose/bom/bom-mapping?hl=en

## Links
- https://developer.android.com/jetpack/androidx/versions/all-channel?hl=en#may_20_2025

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
