### PR TITLE
[#460] 행사 배치도 카드 배경 Shader 구현 (Layered Radial Gradient 쉐이더 코드 작성)

### DIFF
--- a/core/ui/shader/src/commonMain/kotlin/com/droidknights/app/core/shader/components/LayeredRadialGradientBackground.kt
+++ b/core/ui/shader/src/commonMain/kotlin/com/droidknights/app/core/shader/components/LayeredRadialGradientBackground.kt
@@ -1,0 +1,71 @@
+package com.droidknights.app.core.shader.components
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.droidknights.app.core.shader.Shader
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun LayeredShaderBackground(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    ShaderBackground(
+        shader = LayeredRadialGradientBackground,
+        modifier = modifier,
+        content = content,
+    )
+}
+private val LayeredRadialGradientBackground = object : Shader {
+    override val sksl: String
+        get() = """
+uniform float2 uResolution;
+
+half4 main(float2 fragCoord) {
+    float2 center = float2(uResolution.x * 0.5, uResolution.y * 0.5);
+    float dist = distance(fragCoord, center);
+    float width = uResolution.x;
+    float scale = 0.9;
+
+    float opacity = 0.0;
+
+    // 1st circle (0.3 * biggest radius)
+    {
+        float radius = width * scale * 0.3;
+        float t = dist / radius;
+        if (t <= 1.0) {
+            opacity += smoothstep(0.6, 1.0, t) * 0.1;
+        }
+    }
+
+    // 2nd circle (0.5 * biggest radius)
+    {
+        float radius = width * scale * 0.5 ;
+        float t = dist / radius;
+        if (t <= 1.0) {
+            opacity += smoothstep(0.6, 1.0, t) * 0.1;
+        }
+    }
+
+    // 3rd circle (1.0 * biggest radius)
+    {
+        float radius = width * scale * 1.0;
+        float t = dist / radius;
+        if (t <= 1.0) {
+            opacity += smoothstep(0.6, 1.0, t) * 0.1;
+        }
+    }
+
+    opacity = clamp(opacity, 0.0, 1.0);
+    return half4(1.0 * opacity, 1.0 * opacity, 1.0 * opacity, opacity);
+}
+        """.trimIndent()
+}
+
+@Preview
+@Composable
+fun LayeredRadialGradientBackgroundPreview() {
+    LayeredShaderBackground(modifier = Modifier.fillMaxSize()){}
+}

--- a/core/ui/shader/src/commonMain/kotlin/com/droidknights/app/core/shader/components/LayeredRadialGradientBackground.kt
+++ b/core/ui/shader/src/commonMain/kotlin/com/droidknights/app/core/shader/components/LayeredRadialGradientBackground.kt
@@ -67,5 +67,5 @@ half4 main(float2 fragCoord) {
 @Preview
 @Composable
 fun LayeredRadialGradientBackgroundPreview() {
-    LayeredShaderBackground(modifier = Modifier.fillMaxSize()){}
+    LayeredShaderBackground(modifier = Modifier.fillMaxSize()) {}
 }

--- a/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeMapCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeMapCard.kt
@@ -51,12 +51,12 @@ fun HomeMapCard(
                 Text(
                     text = stringResource(Res.string.home_map_card_title),
                     style = KnightsTheme.typography.headlineSmallBL,
-                    color = White
+                    color = White,
                 )
                 Text(
                     text = stringResource(Res.string.home_map_card_desc),
                     style = KnightsTheme.typography.titleSmallM140,
-                    color = White
+                    color = White,
                 )
             }
         }

--- a/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeMapCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeMapCard.kt
@@ -32,6 +32,7 @@ fun HomeMapCard(
     Surface(
         modifier = modifier,
         color = Blue01,
+        contentColor = White,
         shape = RoundedCornerShape(16.dp),
     ) {
         LayeredShaderBackground {
@@ -45,18 +46,15 @@ fun HomeMapCard(
                 Icon(
                     modifier = Modifier.size(36.dp),
                     painter = painterResource(Res.drawable.ic_location),
-                    tint = White,
                     contentDescription = null,
                 )
                 Text(
                     text = stringResource(Res.string.home_map_card_title),
                     style = KnightsTheme.typography.headlineSmallBL,
-                    color = White,
                 )
                 Text(
                     text = stringResource(Res.string.home_map_card_desc),
                     style = KnightsTheme.typography.titleSmallM140,
-                    color = White,
                 )
             }
         }

--- a/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeMapCard.kt
+++ b/feature/home/src/commonMain/kotlin/com/droidknights/app/feature/home/components/HomeMapCard.kt
@@ -1,8 +1,6 @@
 package com.droidknights.app.feature.home.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,14 +9,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.droidknights.app.core.designsystem.components.Icon
 import com.droidknights.app.core.designsystem.components.Surface
 import com.droidknights.app.core.designsystem.components.Text
+import com.droidknights.app.core.designsystem.theme.Blue01
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
+import com.droidknights.app.core.designsystem.theme.White
+import com.droidknights.app.core.shader.components.LayeredShaderBackground
 import droidknights.feature.home.generated.resources.Res
-import droidknights.feature.home.generated.resources.background_home_map_card
 import droidknights.feature.home.generated.resources.home_map_card_desc
 import droidknights.feature.home.generated.resources.home_map_card_title
 import droidknights.feature.home.generated.resources.ic_location
@@ -32,16 +31,10 @@ fun HomeMapCard(
 ) {
     Surface(
         modifier = modifier,
-        color = KnightsTheme.colorScheme.primary,
+        color = Blue01,
         shape = RoundedCornerShape(16.dp),
     ) {
-        Box {
-            Image(
-                modifier = Modifier.matchParentSize(),
-                painter = painterResource(Res.drawable.background_home_map_card),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-            )
+        LayeredShaderBackground {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -52,15 +45,18 @@ fun HomeMapCard(
                 Icon(
                     modifier = Modifier.size(36.dp),
                     painter = painterResource(Res.drawable.ic_location),
+                    tint = White,
                     contentDescription = null,
                 )
                 Text(
                     text = stringResource(Res.string.home_map_card_title),
                     style = KnightsTheme.typography.headlineSmallBL,
+                    color = White
                 )
                 Text(
                     text = stringResource(Res.string.home_map_card_desc),
                     style = KnightsTheme.typography.titleSmallM140,
+                    color = White
                 )
             }
         }
@@ -70,7 +66,7 @@ fun HomeMapCard(
 @Preview
 @Composable
 fun HomeMapCardPreview() {
-    KnightsTheme {
+    KnightsTheme(darkTheme = true) {
         HomeMapCard(
             modifier = Modifier.fillMaxWidth(),
         )


### PR DESCRIPTION
## Issue
- close #460 

## Overview (Required)
행사 배치도 카드 배경을 Shader로 작성해보았습니다. 랜더링 되는 원의 크기는 레이아웃의 width 길이에 비례하여 반응적으로 조정되도록 처리했습니다.
추가적으로, 카드 컴포넌트 색상관련해서 기존엔 colorScheme으로 처리되고 있었는데요, 요건 차후 다크모드일 때도 일관적인 색상 유지를 위해 고정 색상으로 할당해두었습니다.

확인 부탁드립니다.

## 알게된 사실
sksl코드에서 색상을 리턴할 때, Non-Android 타겟에서 일반적인 방법으로 투명도가 안먹는 케이스가 존재했습니다.
요 때는 각각 RGB색상에 투명도를 곱해주어야 한다는 사실을 알았습니다.

### AS-IS
```c
return half4(1.0, 1.0, 1.0, opacity);
```
### TO-BE
```c
return half4(1.0 * opacity, 1.0 * opacity, 1.0 * opacity, opacity);
```

## Screenshot
<img width="1513" alt="image" src="https://github.com/user-attachments/assets/b5a8742d-6301-4c99-acc7-a4691de1639f" />
