### PR TITLE
컨트리뷰터 오타 수정 및 닉네임 최신화

### DIFF
--- a/assets/contributors.json
+++ b/assets/contributors.json
@@ -147,10 +147,10 @@
     ]
   },
   {
-    "login": "taeheeL",
+    "login": "haeti-dev",
     "id": 98825364,
     "years":[
-      2023
+      2024
     ]
   },
   {


### PR DESCRIPTION
## Overview (Required)
- 컨트리뷰트 연도가 잘못 표기되어 수정하였습니다.
- cmp 브렌치 core:network 작업이 끝난 뒤 진행할 #439 이슈 해결 전에 미리 오타를 수정하고자 합니다.

## Links
- https://raw.githubusercontent.com/haeti-dev/DroidKnightsApp/refs/heads/fix/contributors-year-mismatch/assets/contributors.json 해당 링크 진입 시 수정된 json 에셋을 볼 수 있습니다. 

