### PR TITLE
[#517] 디자인 시스템에 nameOfResClass 적용

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -39,6 +39,8 @@ kotlin {
 
 compose.resources {
     publicResClass = true
+    // ref. https://www.jetbrains.com/help/kotlin-multiplatform-dev/whats-new-compose-180.html#option-to-change-the-generated-res-class-name
+    nameOfResClass = "DesignRes"
 }
 
 android.namespace = "com.droidknights.app.core.designsystem"

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/Chip.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/Chip.kt
@@ -18,7 +18,7 @@ import com.droidknights.app.core.designsystem.theme.Graphite
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
 import com.droidknights.app.core.designsystem.theme.LocalContentColor
 import com.droidknights.app.core.designsystem.theme.White
-import droidknights.core.designsystem.generated.resources.Res
+import droidknights.core.designsystem.generated.resources.DesignRes
 import droidknights.core.designsystem.generated.resources.ic_flagbookmark
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -107,7 +107,7 @@ private fun ChipPreview() {
                     )
                     Chip(
                         text = "북마크",
-                        icon = painterResource(Res.drawable.ic_flagbookmark),
+                        icon = painterResource(DesignRes.drawable.ic_flagbookmark),
                         style = ChipStyle.Accent,
                     )
                     Chip(
@@ -132,7 +132,7 @@ private fun ChipPreview() {
                     )
                     Chip(
                         text = "북마크",
-                        icon = painterResource(Res.drawable.ic_flagbookmark),
+                        icon = painterResource(DesignRes.drawable.ic_flagbookmark),
                         style = ChipStyle.Accent,
                     )
                     Chip(

--- a/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/TopAppBar.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/droidknights/app/core/designsystem/components/TopAppBar.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
 import com.droidknights.app.core.designsystem.theme.contentColorFor
-import droidknights.core.designsystem.generated.resources.Res
+import droidknights.core.designsystem.generated.resources.DesignRes
 import droidknights.core.designsystem.generated.resources.ic_arrow_back
 import droidknights.core.designsystem.generated.resources.ic_close
 import droidknights.core.designsystem.generated.resources.ic_session_bookmark_filled
@@ -56,7 +56,7 @@ private fun KnightsTopAppBarPreviewClose() {
                     modifier = modifier,
                 ) {
                     Icon(
-                        painter = painterResource(Res.drawable.ic_close),
+                        painter = painterResource(DesignRes.drawable.ic_close),
                         contentDescription = null,
                     )
                 }
@@ -77,7 +77,7 @@ private fun KnightsTopAppBarPreviewBack() {
                     modifier = it,
                 ) {
                     Icon(
-                        painter = painterResource(Res.drawable.ic_arrow_back),
+                        painter = painterResource(DesignRes.drawable.ic_arrow_back),
                         contentDescription = null,
                     )
                 }
@@ -88,7 +88,7 @@ private fun KnightsTopAppBarPreviewBack() {
                     modifier = modifier,
                 ) {
                     Icon(
-                        painter = painterResource(Res.drawable.ic_session_bookmark_filled),
+                        painter = painterResource(DesignRes.drawable.ic_session_bookmark_filled),
                         contentDescription = null,
                         tint = KnightsTheme.colorScheme.primary,
                     )

--- a/feature/contributor/src/commonMain/composeResources/drawable/ic_close.xml
+++ b/feature/contributor/src/commonMain/composeResources/drawable/ic_close.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
-  <path
-      android:pathData="m256,760 l-56,-56 224,-224 -224,-224 56,-56 224,224 224,-224 56,56 -224,224 224,224 -56,56 -224,-224 -224,224Z"
-      android:fillColor="#FFFFFF"/>
-</vector>

--- a/feature/contributor/src/commonMain/kotlin/com/droidknights/app/feature/contributor/components/ContributorTopAppBar.kt
+++ b/feature/contributor/src/commonMain/kotlin/com/droidknights/app/feature/contributor/components/ContributorTopAppBar.kt
@@ -1,14 +1,14 @@
 package com.droidknights.app.feature.contributor.components
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.droidknights.app.core.designsystem.components.Icon
 import com.droidknights.app.core.designsystem.components.IconButton
 import com.droidknights.app.core.designsystem.components.TopAppBar
+import droidknights.core.designsystem.generated.resources.DesignRes
+import droidknights.core.designsystem.generated.resources.ic_close
 import droidknights.feature.contributor.generated.resources.Res
 import droidknights.feature.contributor.generated.resources.contributor_title
-import droidknights.feature.contributor.generated.resources.ic_close
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -25,7 +25,7 @@ internal fun ContributorTopAppBar(
                 modifier = it,
             ) {
                 Icon(
-                    painter = painterResource(Res.drawable.ic_close),
+                    painter = painterResource(DesignRes.drawable.ic_close),
                     contentDescription = null,
                 )
             }

--- a/feature/license/src/commonMain/kotlin/com/droidknights/app/feature/license/LicenseScreen.kt
+++ b/feature/license/src/commonMain/kotlin/com/droidknights/app/feature/license/LicenseScreen.kt
@@ -15,7 +15,7 @@ import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.m3.libraryColors
 import com.mikepenz.aboutlibraries.ui.compose.rememberLibraries
-import droidknights.core.designsystem.generated.resources.Res.drawable
+import droidknights.core.designsystem.generated.resources.DesignRes
 import droidknights.core.designsystem.generated.resources.ic_arrow_back
 import droidknights.feature.license.generated.resources.Res
 import droidknights.feature.license.generated.resources.license_top_app_bar_title
@@ -44,7 +44,7 @@ internal fun LicenseScreen(
                         modifier = it,
                     ) {
                         Icon(
-                            painter = painterResource(drawable.ic_arrow_back),
+                            painter = painterResource(DesignRes.drawable.ic_arrow_back),
                             contentDescription = null,
                         )
                     }

--- a/feature/session/src/commonMain/composeResources/drawable/ic_flagbookmark.xml
+++ b/feature/session/src/commonMain/composeResources/drawable/ic_flagbookmark.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="36dp"
-    android:viewportWidth="24"
-    android:viewportHeight="36">
-  <path
-      android:pathData="M12,28.588L0,36V0H24V36L12,28.588Z"
-      android:fillColor="#B469FF"/>
-</vector>

--- a/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionCard.kt
+++ b/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionCard.kt
@@ -30,9 +30,10 @@ import com.droidknights.app.core.model.session.Room
 import com.droidknights.app.core.model.session.Session
 import com.droidknights.app.core.model.session.Speaker
 import com.droidknights.app.core.model.session.Tag
+import droidknights.core.designsystem.generated.resources.DesignRes
+import droidknights.core.designsystem.generated.resources.ic_flagbookmark
 import droidknights.feature.session.generated.resources.Res
 import droidknights.feature.session.generated.resources.bookmark
-import droidknights.feature.session.generated.resources.ic_flagbookmark
 import droidknights.feature.session.generated.resources.session_category
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.compose.resources.painterResource
@@ -144,7 +145,7 @@ private fun SessionTrackInfo(
         if (session.isBookmarked) {
             Chip(
                 text = stringResource(resource = Res.string.bookmark),
-                icon = painterResource(resource = Res.drawable.ic_flagbookmark),
+                icon = painterResource(resource = DesignRes.drawable.ic_flagbookmark),
                 style = ChipStyle.Accent,
             )
         }
@@ -191,7 +192,7 @@ private fun BookmarkImage(
     modifier: Modifier = Modifier,
 ) {
     Image(
-        painter = painterResource(resource = Res.drawable.ic_flagbookmark),
+        painter = painterResource(resource = DesignRes.drawable.ic_flagbookmark),
         contentDescription = null,
         modifier = modifier
             .size(

--- a/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionDetailBookmarkStatePopup.kt
+++ b/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionDetailBookmarkStatePopup.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -23,8 +22,9 @@ import com.droidknights.app.core.designsystem.components.Surface
 import com.droidknights.app.core.designsystem.components.Text
 import com.droidknights.app.core.designsystem.theme.Blue01
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
+import droidknights.core.designsystem.generated.resources.DesignRes
+import droidknights.core.designsystem.generated.resources.ic_flagbookmark
 import droidknights.feature.session.generated.resources.Res
-import droidknights.feature.session.generated.resources.ic_flagbookmark
 import droidknights.feature.session.generated.resources.session_detail_bookmark_popup_message
 import droidknights.feature.session.generated.resources.session_detail_unbookmark_popup_message
 import org.jetbrains.compose.resources.painterResource
@@ -58,7 +58,7 @@ internal fun BoxScope.SessionDetailBookmarkStatePopup(
                     .padding(horizontal = 16.dp, vertical = 13.dp),
             ) {
                 Icon(
-                    painter = painterResource(Res.drawable.ic_flagbookmark),
+                    painter = painterResource(DesignRes.drawable.ic_flagbookmark),
                     contentDescription = null,
                     modifier = Modifier
                         .size(10.dp, 14.dp),

--- a/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionDetailTopAppBar.kt
+++ b/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionDetailTopAppBar.kt
@@ -7,14 +7,14 @@ import com.droidknights.app.core.designsystem.components.Icon
 import com.droidknights.app.core.designsystem.components.IconButton
 import com.droidknights.app.core.designsystem.components.TopAppBar
 import com.droidknights.app.core.designsystem.theme.KnightsTheme
+import droidknights.core.designsystem.generated.resources.DesignRes
 import droidknights.core.designsystem.generated.resources.ic_arrow_back
 import droidknights.core.designsystem.generated.resources.ic_session_bookmark
 import droidknights.core.designsystem.generated.resources.ic_session_bookmark_filled
+import droidknights.feature.session.generated.resources.Res
 import droidknights.feature.session.generated.resources.session_detail_title
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import droidknights.core.designsystem.generated.resources.Res as DesignSystemRes
-import droidknights.feature.session.generated.resources.Res as SessionRes
 
 @Composable
 internal fun SessionDetailTopAppBar(
@@ -25,14 +25,14 @@ internal fun SessionDetailTopAppBar(
 ) {
     TopAppBar(
         modifier = modifier,
-        title = stringResource(SessionRes.string.session_detail_title),
+        title = stringResource(Res.string.session_detail_title),
         navigation = {
             IconButton(
                 onClick = onBackClick,
                 modifier = it,
             ) {
                 Icon(
-                    painter = painterResource(DesignSystemRes.drawable.ic_arrow_back),
+                    painter = painterResource(DesignRes.drawable.ic_arrow_back),
                     contentDescription = null,
                 )
             }
@@ -44,9 +44,9 @@ internal fun SessionDetailTopAppBar(
             ) {
                 Icon(
                     painter = if (bookmarked) {
-                        painterResource(DesignSystemRes.drawable.ic_session_bookmark_filled)
+                        painterResource(DesignRes.drawable.ic_session_bookmark_filled)
                     } else {
-                        painterResource(DesignSystemRes.drawable.ic_session_bookmark)
+                        painterResource(DesignRes.drawable.ic_session_bookmark)
                     },
                     contentDescription = null,
                     tint = if (bookmarked) KnightsTheme.colorScheme.primary else Color.Unspecified,

--- a/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionTopAppBar.kt
+++ b/feature/session/src/commonMain/kotlin/com/droidknights/app/feature/session/components/SessionTopAppBar.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.Modifier
 import com.droidknights.app.core.designsystem.components.Icon
 import com.droidknights.app.core.designsystem.components.IconButton
 import com.droidknights.app.core.designsystem.components.TopAppBar
-import droidknights.core.designsystem.generated.resources.Res
+import droidknights.core.designsystem.generated.resources.DesignRes
 import droidknights.core.designsystem.generated.resources.ic_close
 import org.jetbrains.compose.resources.painterResource
 
@@ -23,7 +23,7 @@ fun SessionTopAppBar(
                 modifier = it,
             ) {
                 Icon(
-                    painter = painterResource(Res.drawable.ic_close),
+                    painter = painterResource(DesignRes.drawable.ic_close),
                     contentDescription = null,
                 )
             }


### PR DESCRIPTION
## Issue
- close #517

## Overview (Required)
- compose multiplatform 1.8.1에서 추가된 `nameOfResClass`를 적용하여 Design 시스템이 생성한 Res class와 feature의 Res class 이름이 겹치는 문제를 해결한다.

## Links
- https://www.jetbrains.com/help/kotlin-multiplatform-dev/whats-new-compose-180.html#option-to-change-the-generated-res-class-name


```
// AS-IS
import droidknights.core.designsystem.generated.resources.Res as DesignSystemRes
import droidknights.feature.session.generated.resources.Res as SessionRes

// TO-BE
import droidknights.core.designsystem.generated.resources.DesignRes
import droidknights.feature.session.generated.resources.Res
```
