### PR TITLE
(REFACTOR)[#554] BaseViewModel 적용을 통한, 'Navigator'와 'errorFlow' 공통 처리 

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -12,4 +12,5 @@ android {
 dependencies {
     implementation(projects.core.designsystem)
     implementation(projects.core.domain.domainSessionApi)
+    implementation(projects.core.router.routerApi)
 }

--- a/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
+++ b/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
@@ -12,35 +12,31 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-open class BaseViewModel
+open class BaseViewModel @Inject constructor() : ViewModel() {
+    protected val internalErrorFlow = MutableSharedFlow<Throwable>()
+    val errorFlow = internalErrorFlow.asSharedFlow()
+
     @Inject
-    constructor() : ViewModel() {
-        protected val _errorFlow = MutableSharedFlow<Throwable>()
-        val errorFlow = _errorFlow.asSharedFlow()
+    lateinit var navigator: Navigator
 
-        @Inject
-        lateinit var navigator: Navigator
-
-        @VisibleForTesting
-        fun injectNavigator(navigator: Navigator) {
-            this.navigator = navigator
-        }
-
-        fun navigateBack() =
-            viewModelScope.launch {
-                navigator.navigateBack()
-            }
-
-        fun navigateWeb(url: String) =
-            viewModelScope.launch {
-                navigator.navigateWeb(url)
-            }
-
-        fun navigateTo(
-            route: Route,
-            saveState: Boolean = false,
-            launchSingleTop: Boolean = false,
-        ) = viewModelScope.launch {
-            navigator.navigate(route, saveState, launchSingleTop)
-        }
+    @VisibleForTesting
+    fun injectNavigator(navigator: Navigator) {
+        this.navigator = navigator
     }
+
+    fun navigateBack() = viewModelScope.launch {
+        navigator.navigateBack()
+    }
+
+    fun navigateWeb(url: String) = viewModelScope.launch {
+        navigator.navigateWeb(url)
+    }
+
+    fun navigateTo(
+        route: Route,
+        saveState: Boolean = false,
+        launchSingleTop: Boolean = false
+    ) = viewModelScope.launch {
+            navigator.navigate(route, saveState, launchSingleTop)
+    }
+}

--- a/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
+++ b/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
@@ -1,5 +1,6 @@
 package com.droidknights.app.core.ui
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.router.api.Navigator
@@ -13,11 +14,16 @@ import javax.inject.Inject
 @HiltViewModel
 open class BaseViewModel @Inject constructor(): ViewModel() {
 
+  protected val _errorFlow = MutableSharedFlow<Throwable>()
+  val errorFlow = _errorFlow.asSharedFlow()
+
   @Inject
   lateinit var navigator: Navigator
 
-  protected val _errorFlow = MutableSharedFlow<Throwable>()
-  val errorFlow = _errorFlow.asSharedFlow()
+  @VisibleForTesting
+  fun injectNavigator(navigator: Navigator) {
+    this.navigator = navigator
+  }
 
   fun navigateBack() = viewModelScope.launch {
     navigator.navigateBack()

--- a/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
+++ b/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
@@ -1,0 +1,37 @@
+package com.droidknights.app.core.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.droidknights.app.core.router.api.Navigator
+import com.droidknights.app.core.router.api.model.Route
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+open class BaseViewModel @Inject constructor(): ViewModel() {
+
+  @Inject
+  lateinit var navigator: Navigator
+
+  protected val _errorFlow = MutableSharedFlow<Throwable>()
+  val errorFlow = _errorFlow.asSharedFlow()
+
+  fun navigateBack() = viewModelScope.launch {
+    navigator.navigateBack()
+  }
+
+  fun navigateWeb(url: String) = viewModelScope.launch {
+    navigator.navigateWeb(url)
+  }
+
+  fun navigateTo(
+    route: Route,
+    saveState: Boolean = false,
+    launchSingleTop: Boolean = false
+  ) = viewModelScope.launch {
+    navigator.navigate(route, saveState, launchSingleTop)
+  }
+}

--- a/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
+++ b/core/ui/src/main/java/com/droidknights/app/core/ui/BaseViewModel.kt
@@ -12,32 +12,35 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-open class BaseViewModel @Inject constructor(): ViewModel() {
+open class BaseViewModel
+    @Inject
+    constructor() : ViewModel() {
+        protected val _errorFlow = MutableSharedFlow<Throwable>()
+        val errorFlow = _errorFlow.asSharedFlow()
 
-  protected val _errorFlow = MutableSharedFlow<Throwable>()
-  val errorFlow = _errorFlow.asSharedFlow()
+        @Inject
+        lateinit var navigator: Navigator
 
-  @Inject
-  lateinit var navigator: Navigator
+        @VisibleForTesting
+        fun injectNavigator(navigator: Navigator) {
+            this.navigator = navigator
+        }
 
-  @VisibleForTesting
-  fun injectNavigator(navigator: Navigator) {
-    this.navigator = navigator
-  }
+        fun navigateBack() =
+            viewModelScope.launch {
+                navigator.navigateBack()
+            }
 
-  fun navigateBack() = viewModelScope.launch {
-    navigator.navigateBack()
-  }
+        fun navigateWeb(url: String) =
+            viewModelScope.launch {
+                navigator.navigateWeb(url)
+            }
 
-  fun navigateWeb(url: String) = viewModelScope.launch {
-    navigator.navigateWeb(url)
-  }
-
-  fun navigateTo(
-    route: Route,
-    saveState: Boolean = false,
-    launchSingleTop: Boolean = false
-  ) = viewModelScope.launch {
-    navigator.navigate(route, saveState, launchSingleTop)
-  }
-}
+        fun navigateTo(
+            route: Route,
+            saveState: Boolean = false,
+            launchSingleTop: Boolean = false,
+        ) = viewModelScope.launch {
+            navigator.navigate(route, saveState, launchSingleTop)
+        }
+    }

--- a/feature/bookmark/src/main/java/com/droidknights/app/feature/bookmark/BookmarkViewModel.kt
+++ b/feature/bookmark/src/main/java/com/droidknights/app/feature/bookmark/BookmarkViewModel.kt
@@ -1,11 +1,10 @@
 package com.droidknights.app.feature.bookmark
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.domain.session.usecase.api.DeleteBookmarkedSessionUseCase
 import com.droidknights.app.core.domain.session.usecase.api.GetBookmarkedSessionsUseCase
 import com.droidknights.app.core.model.session.Session
-import com.droidknights.app.core.router.api.Navigator
+import com.droidknights.app.core.ui.BaseViewModel
 import com.droidknights.app.feature.bookmark.model.BookmarkItemUiState
 import com.droidknights.app.feature.bookmark.model.BookmarkUiState
 import com.droidknights.app.feature.session.api.RouteSession
@@ -13,9 +12,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentSet
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -29,12 +26,8 @@ import javax.inject.Inject
 @HiltViewModel
 class BookmarkViewModel @Inject constructor(
     private val getBookmarkedSessionsUseCase: GetBookmarkedSessionsUseCase,
-    private val deleteBookmarkedSessionUseCase: DeleteBookmarkedSessionUseCase,
-    private val navigator: Navigator,
-) : ViewModel() {
-
-    private val _errorFlow = MutableSharedFlow<Throwable>()
-    val errorFlow = _errorFlow.asSharedFlow()
+    private val deleteBookmarkedSessionUseCase: DeleteBookmarkedSessionUseCase
+) : BaseViewModel() {
 
     private val _bookmarkUiState = MutableStateFlow<BookmarkUiState>(BookmarkUiState.Loading)
     val bookmarkUiState = _bookmarkUiState.asStateFlow()
@@ -132,10 +125,8 @@ class BookmarkViewModel @Inject constructor(
         if (state !is BookmarkUiState.Success || state.isEditMode) {
             return
         }
-        viewModelScope.launch {
-            navigator.navigate(
-                route = RouteSession(sessionId = session.id),
-            )
-        }
+        navigateTo(
+            route = RouteSession(sessionId = session.id)
+        )
     }
 }

--- a/feature/bookmark/src/main/java/com/droidknights/app/feature/bookmark/BookmarkViewModel.kt
+++ b/feature/bookmark/src/main/java/com/droidknights/app/feature/bookmark/BookmarkViewModel.kt
@@ -67,7 +67,7 @@ class BookmarkViewModel @Inject constructor(
                     }
                 }
             }.catch { throwable ->
-                _errorFlow.emit(throwable)
+                internalErrorFlow.emit(throwable)
             }.collect { _bookmarkUiState.value = it }
         }
     }
@@ -116,7 +116,7 @@ class BookmarkViewModel @Inject constructor(
                 state.copy(selectedSessionIds = persistentSetOf())
             }
         }.catch { throwable ->
-            _errorFlow.emit(throwable)
+            internalErrorFlow.emit(throwable)
         }.launchIn(viewModelScope)
     }
 

--- a/feature/bookmark/src/test/java/com/droidknights/app/feature/bookmark/BookmarkViewModelTest.kt
+++ b/feature/bookmark/src/test/java/com/droidknights/app/feature/bookmark/BookmarkViewModelTest.kt
@@ -48,9 +48,8 @@ class BookmarkViewModelTest {
         // given & when
         viewModel = BookmarkViewModel(
             getBookmarkedSessionsUseCase,
-            deleteBookmarkedSessionUseCase,
-            navigator
-        )
+            deleteBookmarkedSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         // then
         viewModel.bookmarkUiState.test {
@@ -76,9 +75,8 @@ class BookmarkViewModelTest {
         // given
         viewModel = BookmarkViewModel(
             getBookmarkedSessionsUseCase,
-            deleteBookmarkedSessionUseCase,
-            navigator
-        )
+            deleteBookmarkedSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         viewModel.bookmarkUiState.test {
             val initialIsEditMode = (awaitItem() as BookmarkUiState.Success).isEditMode
@@ -98,9 +96,8 @@ class BookmarkViewModelTest {
         // given
         viewModel = BookmarkViewModel(
             getBookmarkedSessionsUseCase,
-            deleteBookmarkedSessionUseCase,
-            navigator
-        )
+            deleteBookmarkedSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         // when
         viewModel.selectSession(mockSession1)
@@ -120,9 +117,9 @@ class BookmarkViewModelTest {
         // given
         viewModel = BookmarkViewModel(
             getBookmarkedSessionsUseCase,
-            deleteBookmarkedSessionUseCase,
-            navigator
-        )
+            deleteBookmarkedSessionUseCase
+        ).also { it.injectNavigator(navigator) }
+
         viewModel.selectSession(mockSession1)
 
         // when
@@ -144,9 +141,9 @@ class BookmarkViewModelTest {
         coEvery { deleteBookmarkedSessionUseCase(persistentSetOf("1")) } just Runs
         viewModel = BookmarkViewModel(
             getBookmarkedSessionsUseCase,
-            deleteBookmarkedSessionUseCase,
-            navigator
-        )
+            deleteBookmarkedSessionUseCase
+        ).also { it.injectNavigator(navigator) }
+
         viewModel.selectSession(mockSession1)
 
         // when
@@ -167,9 +164,8 @@ class BookmarkViewModelTest {
         coEvery { navigator.navigate(RouteSession(sessionId = mockSession2.id)) } just Runs
         viewModel = BookmarkViewModel(
             getBookmarkedSessionsUseCase,
-            deleteBookmarkedSessionUseCase,
-            navigator
-        )
+            deleteBookmarkedSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         // when
         viewModel.redirectToSessionScreen(mockSession2)

--- a/feature/contributor/src/main/java/com/droidknights/app/feature/contributor/ContributorViewModel.kt
+++ b/feature/contributor/src/main/java/com/droidknights/app/feature/contributor/ContributorViewModel.kt
@@ -1,9 +1,8 @@
 package com.droidknights.app.feature.contributor
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.domain.contributor.usecase.api.GetContributorsUseCase
-import com.droidknights.app.core.router.api.Navigator
+import com.droidknights.app.core.ui.BaseViewModel
 import com.droidknights.app.feature.contributor.model.ContributorsUiState
 import com.droidknights.app.feature.contributor.model.convert.toContributorsUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,12 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ContributorViewModel @Inject constructor(
-    getContributorsUseCase: GetContributorsUseCase,
-    private val navigator: Navigator,
-) : ViewModel() {
-
-    private val _errorFlow = MutableSharedFlow<Throwable>()
-    val errorFlow = _errorFlow.asSharedFlow()
+    getContributorsUseCase: GetContributorsUseCase
+) : BaseViewModel() {
 
     val uiState: StateFlow<ContributorsUiState> by lazy {
         getContributorsUseCase()
@@ -39,9 +34,5 @@ class ContributorViewModel @Inject constructor(
                 started = SharingStarted.WhileSubscribed(5_000),
                 initialValue = ContributorsUiState.Loading
             )
-    }
-
-    fun navigateBack() = viewModelScope.launch {
-        navigator.navigateBack()
     }
 }

--- a/feature/contributor/src/main/java/com/droidknights/app/feature/contributor/ContributorViewModel.kt
+++ b/feature/contributor/src/main/java/com/droidknights/app/feature/contributor/ContributorViewModel.kt
@@ -6,14 +6,11 @@ import com.droidknights.app.core.ui.BaseViewModel
 import com.droidknights.app.feature.contributor.model.ContributorsUiState
 import com.droidknights.app.feature.contributor.model.convert.toContributorsUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -27,7 +24,7 @@ class ContributorViewModel @Inject constructor(
                 it.toContributorsUiState()
             }
             .catch { throwable ->
-                _errorFlow.emit(throwable)
+                internalErrorFlow.emit(throwable)
             }
             .stateIn(
                 scope = viewModelScope,

--- a/feature/contributor/src/test/java/com/droidknights/app/feature/contributor/ContributorViewModelTest.kt
+++ b/feature/contributor/src/test/java/com/droidknights/app/feature/contributor/ContributorViewModelTest.kt
@@ -31,7 +31,9 @@ internal class ContributorViewModelTest {
     fun `컨트리뷰터 데이터를 확인할 수 있다`() = runTest {
         // given
         coEvery { getContributorsUseCase() } returns flowOf(fakeContributors)
-        viewModel = ContributorViewModel(getContributorsUseCase, navigator)
+        viewModel = ContributorViewModel(getContributorsUseCase).also {
+            it.injectNavigator(navigator)
+        }
 
         // when & then
         viewModel.uiState.test {
@@ -44,7 +46,9 @@ internal class ContributorViewModelTest {
     fun `navigateBack이 호출될 때 navigator에게 위임한다`() = runTest {
         // suspend 함수 호출에 대한 stub
         coEvery { navigator.navigateBack() } just Runs
-        viewModel = ContributorViewModel(getContributorsUseCase, navigator)
+        viewModel = ContributorViewModel(getContributorsUseCase).also {
+            it.injectNavigator(navigator)
+        }
 
         // when
         viewModel.navigateBack()

--- a/feature/home/src/main/java/com/droidknights/app/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/droidknights/app/feature/home/HomeScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.droidknights.app.feature.contributor.api.RouteContributor
 import com.droidknights.app.feature.home.component.ContributorCard
 import com.droidknights.app.feature.home.component.SessionCard
 import com.droidknights.app.feature.home.component.SponsorCard
 import com.droidknights.app.feature.home.model.SponsorsUiState
+import com.droidknights.app.feature.session.api.RouteSession
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -35,9 +37,9 @@ internal fun HomeRoute(
     HomeScreen(
         padding = padding,
         sponsorsUiState = sponsorsUiState,
-        onSessionClick = viewModel::navigateSession,
-        onContributorClick = viewModel::navigateContributor,
-        onOrganizationSponsorClick = viewModel::navigateOrganizationSponsor,
+        onSessionClick = { viewModel.navigateTo(RouteSession()) },
+        onContributorClick = { viewModel.navigateTo(RouteContributor) },
+        onOrganizationSponsorClick = viewModel::navigateWeb,
     )
 }
 

--- a/feature/home/src/main/java/com/droidknights/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/droidknights/app/feature/home/HomeViewModel.kt
@@ -1,33 +1,23 @@
 package com.droidknights.app.feature.home
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.domain.sponsor.usecase.api.GetSponsorsUseCase
-import com.droidknights.app.core.router.api.Navigator
-import com.droidknights.app.feature.contributor.api.RouteContributor
+import com.droidknights.app.core.ui.BaseViewModel
 import com.droidknights.app.feature.home.model.SponsorsUiState
-import com.droidknights.app.feature.session.api.RouteSession
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    getSponsorsUseCase: GetSponsorsUseCase,
-    private val navigator: Navigator,
-) : ViewModel() {
-
-    private val _errorFlow = MutableSharedFlow<Throwable>()
-    val errorFlow get() = _errorFlow.asSharedFlow()
+    getSponsorsUseCase: GetSponsorsUseCase
+) : BaseViewModel() {
 
     val sponsorsUiState: StateFlow<SponsorsUiState> =
         flow { emit(getSponsorsUseCase()) }
@@ -46,16 +36,4 @@ class HomeViewModel @Inject constructor(
                 started = SharingStarted.WhileSubscribed(5_000),
                 initialValue = SponsorsUiState.Loading,
             )
-
-    fun navigateSession() = viewModelScope.launch {
-        navigator.navigate(RouteSession())
-    }
-
-    fun navigateContributor() = viewModelScope.launch {
-        navigator.navigate(RouteContributor)
-    }
-
-    fun navigateOrganizationSponsor(url: String) = viewModelScope.launch {
-        navigator.navigateWeb(url)
-    }
 }

--- a/feature/home/src/main/java/com/droidknights/app/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/droidknights/app/feature/home/HomeViewModel.kt
@@ -29,7 +29,7 @@ class HomeViewModel @Inject constructor(
                 }
             }
             .catch { throwable ->
-                _errorFlow.emit(throwable)
+                internalErrorFlow.emit(throwable)
             }
             .stateIn(
                 scope = viewModelScope,

--- a/feature/home/src/test/java/com/droidknights/app/feature/home/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/droidknights/app/feature/home/HomeViewModelTest.kt
@@ -30,7 +30,9 @@ internal class HomeViewModelTest {
     fun `후원사 리스트가 비어있다면 후원사 데이터를 확인할 수 없다`() = runTest {
         // given
         coEvery { getSponsorsUseCase() } returns emptyList()
-        viewModel = HomeViewModel(getSponsorsUseCase, navigator)
+        viewModel = HomeViewModel(getSponsorsUseCase).also {
+            it.injectNavigator(navigator)
+        }
 
         // when & then
         viewModel.sponsorsUiState.test {
@@ -43,7 +45,9 @@ internal class HomeViewModelTest {
     fun `후원사 리스트가 존재한다면 후원사 데이터를 확인할 수 있다`() = runTest {
         // given
         coEvery { getSponsorsUseCase() } returns fakeSponsors
-        viewModel = HomeViewModel(getSponsorsUseCase, navigator)
+        viewModel = HomeViewModel(getSponsorsUseCase).also {
+            it.injectNavigator(navigator)
+        }
 
         // when & then
         viewModel.sponsorsUiState.test {
@@ -56,10 +60,12 @@ internal class HomeViewModelTest {
     fun `navigate(RouteSession)가 호출될 때 navigator에게 위임한다`() = runTest {
         // given
         coEvery { navigator.navigate(RouteSession()) } just Runs
-        viewModel = HomeViewModel(getSponsorsUseCase, navigator)
+        viewModel = HomeViewModel(getSponsorsUseCase).also {
+            it.injectNavigator(navigator)
+        }
 
         // when
-        viewModel.navigateSession()
+        viewModel.navigateTo(RouteSession())
 
         // then
         coVerify(exactly = 1) { navigator.navigate(RouteSession()) }
@@ -69,10 +75,12 @@ internal class HomeViewModelTest {
     fun `navigate(RouteContributor)가 호출될 때 navigator에게 위임한다`() = runTest {
         // given
         coEvery { navigator.navigate(RouteContributor) } just Runs
-        viewModel = HomeViewModel(getSponsorsUseCase, navigator)
+        viewModel = HomeViewModel(getSponsorsUseCase).also {
+            it.injectNavigator(navigator)
+        }
 
         // when
-        viewModel.navigateContributor()
+        viewModel.navigateTo(RouteContributor)
 
         // then
         coVerify(exactly = 1) { navigator.navigate(RouteContributor) }

--- a/feature/main/src/main/java/com/droidknights/app/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/droidknights/app/feature/main/MainActivity.kt
@@ -12,6 +12,7 @@ import com.droidknights.app.core.designsystem.theme.KnightsTheme
 import com.droidknights.app.core.router.LaunchedRouter
 import com.droidknights.app.feature.bookmark.api.RouteBookmark
 import com.droidknights.app.feature.home.api.RouteHome
+import com.droidknights.app.feature.session.api.RouteSessionDetail
 import com.droidknights.app.feature.setting.api.RouteSetting
 import com.droidknights.app.widget.DroidKnightsWidget.Companion.KEY_SESSION_ID
 import com.droidknights.app.widget.sendWidgetUpdateCommand
@@ -47,7 +48,7 @@ class MainActivity : ComponentActivity() {
 
             LaunchedEffect(sessionId) {
                 sessionId?.let {
-                    viewModel.navigateSessionDetail(it)
+                    viewModel.navigateTo(RouteSessionDetail(it))
                 }
             }
 
@@ -56,9 +57,21 @@ class MainActivity : ComponentActivity() {
                     navigator = navigator,
                     onTabSelected = {
                         when (it.route) {
-                            is RouteSetting -> viewModel.navigateSetting()
-                            is RouteBookmark -> viewModel.navigateBookmark()
-                            is RouteHome -> viewModel.navigateHome()
+                            is RouteSetting -> viewModel.navigateTo(
+                                route = RouteSetting,
+                                saveState = true,
+                                launchSingleTop = true
+                            )
+                            is RouteBookmark -> viewModel.navigateTo(
+                                route = RouteBookmark,
+                                saveState = true,
+                                launchSingleTop = true
+                            )
+                            is RouteHome -> viewModel.navigateTo(
+                                route = RouteHome,
+                                saveState = true,
+                                launchSingleTop = true
+                            )
                         }
                     },
                 )

--- a/feature/main/src/main/java/com/droidknights/app/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/droidknights/app/feature/main/MainViewModel.kt
@@ -1,50 +1,15 @@
 package com.droidknights.app.feature.main
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.data.settings.api.SettingsRepository
-import com.droidknights.app.core.router.api.Navigator
-import com.droidknights.app.feature.bookmark.api.RouteBookmark
-import com.droidknights.app.feature.home.api.RouteHome
-import com.droidknights.app.feature.session.api.RouteSessionDetail
-import com.droidknights.app.feature.setting.api.RouteSetting
+import com.droidknights.app.core.ui.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 internal class MainViewModel @Inject constructor(
-    settingsRepository: SettingsRepository,
-    private val navigator: Navigator,
-) : ViewModel() {
+    settingsRepository: SettingsRepository
+) : BaseViewModel() {
 
     val isDarkTheme = settingsRepository.flowIsDarkTheme()
 
-    fun navigateSessionDetail(sessionId: String) = viewModelScope.launch {
-        navigator.navigate(RouteSessionDetail(sessionId))
-    }
-
-    fun navigateSetting() = viewModelScope.launch {
-        navigator.navigate(
-            route = RouteSetting,
-            saveState = true,
-            launchSingleTop = true,
-        )
-    }
-
-    fun navigateBookmark() = viewModelScope.launch {
-        navigator.navigate(
-            route = RouteBookmark,
-            saveState = true,
-            launchSingleTop = true,
-        )
-    }
-
-    fun navigateHome() = viewModelScope.launch {
-        navigator.navigate(
-            route = RouteHome,
-            saveState = true,
-            launchSingleTop = true,
-        )
-    }
 }

--- a/feature/main/src/main/java/com/droidknights/app/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/droidknights/app/feature/main/MainViewModel.kt
@@ -11,5 +11,4 @@ internal class MainViewModel @Inject constructor(
 ) : BaseViewModel() {
 
     val isDarkTheme = settingsRepository.flowIsDarkTheme()
-
 }

--- a/feature/main/src/test/java/com/droidknights/app/feature/main/MainViewModelTest.kt
+++ b/feature/main/src/test/java/com/droidknights/app/feature/main/MainViewModelTest.kt
@@ -35,7 +35,8 @@ class MainViewModelTest {
     fun setup() {
         // given
         every { settingsRepository.flowIsDarkTheme() } returns flowOf(false)
-        viewModel = MainViewModel(settingsRepository, navigator)
+        viewModel = MainViewModel(settingsRepository)
+        viewModel.injectNavigator(navigator)
     }
 
     @Test
@@ -52,7 +53,7 @@ class MainViewModelTest {
         coEvery { navigator.navigate(RouteSessionDetail(fakeSessionId)) } just Runs
 
         // when
-        viewModel.navigateSessionDetail(fakeSessionId)
+        viewModel.navigateTo(RouteSessionDetail(fakeSessionId))
 
         // then
         coVerify(exactly = 1) { navigator.navigate(RouteSessionDetail(fakeSessionId)) }
@@ -70,7 +71,11 @@ class MainViewModelTest {
         } just Runs
 
         // when
-        viewModel.navigateSetting()
+        viewModel.navigateTo(
+            route = RouteSetting,
+            saveState = true,
+            launchSingleTop = true
+        )
 
         // then
         coVerify(exactly = 1) {
@@ -94,14 +99,18 @@ class MainViewModelTest {
         } just Runs
 
         // when
-        viewModel.navigateBookmark()
+        viewModel.navigateTo(
+            route = RouteBookmark,
+            saveState = true,
+            launchSingleTop = true
+        )
 
         // then
         coVerify(exactly = 1) {
             navigator.navigate(
                 route = RouteBookmark,
                 saveState = true,
-                launchSingleTop = true,
+                launchSingleTop = true
             )
         }
     }
@@ -118,7 +127,11 @@ class MainViewModelTest {
         } just Runs
 
         // when
-        viewModel.navigateHome()
+        viewModel.navigateTo(
+            route = RouteHome,
+            saveState = true,
+            launchSingleTop = true
+        )
 
         // then
         coVerify(exactly = 1) {

--- a/feature/session/src/main/java/com/droidknights/app/feature/session/detail/SessionDetailViewModel.kt
+++ b/feature/session/src/main/java/com/droidknights/app/feature/session/detail/SessionDetailViewModel.kt
@@ -1,11 +1,10 @@
 package com.droidknights.app.feature.session.detail
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.domain.session.usecase.api.BookmarkSessionUseCase
 import com.droidknights.app.core.domain.session.usecase.api.GetBookmarkedSessionIdsUseCase
 import com.droidknights.app.core.domain.session.usecase.api.GetSessionUseCase
-import com.droidknights.app.core.router.api.Navigator
+import com.droidknights.app.core.ui.BaseViewModel
 import com.droidknights.app.feature.session.detail.model.SessionDetailEffect
 import com.droidknights.app.feature.session.detail.model.SessionDetailUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,9 +20,8 @@ import javax.inject.Inject
 class SessionDetailViewModel @Inject constructor(
     private val getSessionUseCase: GetSessionUseCase,
     getBookmarkedSessionIdsUseCase: GetBookmarkedSessionIdsUseCase,
-    private val bookmarkSessionUseCase: BookmarkSessionUseCase,
-    private val navigator: Navigator,
-) : ViewModel() {
+    private val bookmarkSessionUseCase: BookmarkSessionUseCase
+) : BaseViewModel() {
 
     private val _sessionUiState =
         MutableStateFlow<SessionDetailUiState>(SessionDetailUiState.Loading)
@@ -71,9 +69,5 @@ class SessionDetailViewModel @Inject constructor(
         viewModelScope.launch {
             _sessionUiEffect.value = SessionDetailEffect.Idle
         }
-    }
-
-    fun navigateBack() = viewModelScope.launch {
-        navigator.navigateBack()
     }
 }

--- a/feature/session/src/main/java/com/droidknights/app/feature/session/list/SessionListViewModel.kt
+++ b/feature/session/src/main/java/com/droidknights/app/feature/session/list/SessionListViewModel.kt
@@ -40,7 +40,7 @@ class SessionListViewModel @Inject constructor(
             )
         }
             .catch { throwable ->
-                _errorFlow.emit(throwable)
+                internalErrorFlow.emit(throwable)
             }
             .onEach { combinedUiState ->
                 _uiState.value = combinedUiState

--- a/feature/session/src/main/java/com/droidknights/app/feature/session/list/SessionListViewModel.kt
+++ b/feature/session/src/main/java/com/droidknights/app/feature/session/list/SessionListViewModel.kt
@@ -1,17 +1,14 @@
 package com.droidknights.app.feature.session.list
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.droidknights.app.core.domain.session.usecase.api.GetBookmarkedSessionIdsUseCase
 import com.droidknights.app.core.domain.session.usecase.api.GetSessionsUseCase
-import com.droidknights.app.core.router.api.Navigator
+import com.droidknights.app.core.ui.BaseViewModel
 import com.droidknights.app.feature.session.api.RouteSessionDetail
 import com.droidknights.app.feature.session.list.model.SessionUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -23,12 +20,8 @@ import javax.inject.Inject
 @HiltViewModel
 class SessionListViewModel @Inject constructor(
     getSessionsUseCase: GetSessionsUseCase,
-    getBookmarkedSessionIdsUseCase: GetBookmarkedSessionIdsUseCase,
-    private val navigator: Navigator,
-) : ViewModel() {
-
-    private val _errorFlow = MutableSharedFlow<Throwable>()
-    val errorFlow = _errorFlow.asSharedFlow()
+    getBookmarkedSessionIdsUseCase: GetBookmarkedSessionIdsUseCase
+) : BaseViewModel() {
 
     private val _uiState = MutableStateFlow<SessionUiState>(SessionUiState.Loading)
     val uiState = _uiState.asStateFlow()
@@ -57,9 +50,5 @@ class SessionListViewModel @Inject constructor(
 
     fun navigateSessionDetail(sessionId: String) = viewModelScope.launch {
         navigator.navigate(RouteSessionDetail(sessionId))
-    }
-
-    fun navigateBack() = viewModelScope.launch {
-        navigator.navigateBack()
     }
 }

--- a/feature/session/src/test/java/com/droidknights/app/feature/session/detail/SessionDetailViewModelTest.kt
+++ b/feature/session/src/test/java/com/droidknights/app/feature/session/detail/SessionDetailViewModelTest.kt
@@ -60,9 +60,8 @@ class SessionDetailViewModelTest {
         viewModel = SessionDetailViewModel(
             getSessionUseCase,
             getBookmarkedSessionIdsUseCase,
-            bookmarkSessionUseCase,
-            navigator,
-        )
+            bookmarkSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         // when
         viewModel.fetchSession(sessionId)
@@ -83,9 +82,8 @@ class SessionDetailViewModelTest {
         viewModel = SessionDetailViewModel(
             getSessionUseCase,
             getBookmarkedSessionIdsUseCase,
-            bookmarkSessionUseCase,
-            navigator,
-        )
+            bookmarkSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         // when
         viewModel.fetchSession(sessionId)
@@ -112,9 +110,9 @@ class SessionDetailViewModelTest {
         viewModel = SessionDetailViewModel(
             getSessionUseCase,
             getBookmarkedSessionIdsUseCase,
-            bookmarkSessionUseCase,
-            navigator,
-        )
+            bookmarkSessionUseCase
+        ).also { it.injectNavigator(navigator) }
+
         viewModel.fetchSession(sessionId)
 
         // when
@@ -134,9 +132,8 @@ class SessionDetailViewModelTest {
         viewModel = SessionDetailViewModel(
             getSessionUseCase,
             getBookmarkedSessionIdsUseCase,
-            bookmarkSessionUseCase,
-            navigator,
-        )
+            bookmarkSessionUseCase
+        ).also { it.injectNavigator(navigator) }
 
         // when
         viewModel.navigateBack()

--- a/feature/session/src/test/java/com/droidknights/app/feature/session/list/SessionListViewModelTest.kt
+++ b/feature/session/src/test/java/com/droidknights/app/feature/session/list/SessionListViewModelTest.kt
@@ -53,9 +53,8 @@ internal class SessionListViewModelTest {
         // given
         viewModel = SessionListViewModel(
             getSessionsUseCase,
-            getBookmarkedSessionIdsUseCase,
-            navigator,
-        )
+            getBookmarkedSessionIdsUseCase
+        ).also { it.injectNavigator(navigator) }
     }
 
     @Test


### PR DESCRIPTION
## Issue
- close #554

## Overview (Required)
- 현재 대부분의 ViewModel(SessionDetail, SessionList, Home, Bookmark, Contributor, Main)에선 'Navigator'를 활용한 화면 이동 로직이 정의되어 있습니다.
- 현재 대부분의 ViewModel에선 '_errorFlow = MutableSharedFlow()'를 활용한 에러처리 플로우가 정의되어 있습니다.
- 따라서 위 2가지('_errorFlow', 'Navigator')를 BaseViewModel로의 정의 및 공통 로직으로 관리하고자 합니다.
- 기대효과로, 기존 ViewModel의 중복로직을 크게 감소시킬 수 있습니다. (eg., MainViewModel의 라인 수 50 -> 15 감소)

## Verification
- BaseViewModel의 신규 정의 및 기존 *.ViewModel들에 상속 처리로 인해, *.ViewModelTest 검증 완료.
